### PR TITLE
feat: Enhance Docker Compose configuration with new services 

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,9 +1,11 @@
 # Dockerfile.sandbox
 FROM ubuntu:22.04
 
-# Install dependencies
+# Install dependencies including Python and network testing tools
 RUN apt-get update && apt-get install -y \
-    zsh git curl \
+    zsh git curl python3 python3-pip \
+    netcat-openbsd tcpdump iputils-ping net-tools \
+    procps lsof \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Oh My Zsh + autosuggestions + syntax highlighting

--- a/README.md
+++ b/README.md
@@ -130,9 +130,57 @@ The `scan --deep` command performs:
 
 ## Docker
 
+### Services
+
+**Sandbox (Development Environment)**
+Interactive development and testing environment with network tools.
+
 ```bash
-docker-compose up -d
-docker exec -it monix_sandbox bash
+# Start sandbox (interactive shell)
+docker-compose up sandbox
+
+# Or run in background and exec into it
+docker-compose up -d sandbox
+docker exec -it monix_sandbox zsh
+```
+
+**Test Environment**
+Environment with pytest and testing dependencies.
+
+```bash
+# Start test environment
+docker-compose up test
+
+# Run tests
+docker-compose run test pytest
+
+# Interactive shell
+docker-compose run test /bin/bash
+```
+
+**Monix Service (Production)**
+Run Monix commands on-demand (doesn't run continuously).
+
+```bash
+# Run Monix watch dashboard
+docker-compose run monix bash -c "pip install -e . && monix --watch"
+
+# Run other commands
+docker-compose run monix bash -c "pip install -e . && monix --status"
+docker-compose run monix bash -c "pip install -e . && monix --scan"
+```
+
+### Quick Commands
+
+```bash
+# Start sandbox for testing
+docker-compose up sandbox
+
+# Stop all containers
+docker-compose down
+
+# Rebuild sandbox image
+docker-compose build sandbox
 ```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,23 @@
 version: "3.9"
 
 services:
+  # Main Monix service - only runs when explicitly started
+  # Usage: docker-compose run monix monix --watch
   monix:
     image: python:3.11-slim
     container_name: monix
     working_dir: /app
     volumes:
       - ./:/app
-    command: bash -c "pip install -e . && monix --watch"
     network_mode: host
     privileged: true
     stdin_open: true
     tty: true
+    profiles:
+      - production  # Only start with --profile production
+    # No default command - must specify when running
 
+  # Development sandbox for testing
   sandbox:
     build:
       context: .
@@ -22,4 +27,20 @@ services:
     volumes:
       - ./:/app
     tty: true
+    stdin_open: true
     command: /bin/bash
+    # Keep container running but don't auto-start
+    restart: "no"
+
+  # Test environment with pytest and testing tools
+  test:
+    image: python:3.11-slim
+    container_name: monix_test
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command: bash -c "pip install -e . && pip install pytest pytest-cov && /bin/bash"
+    tty: true
+    stdin_open: true
+    environment:
+      - PYTHONUNBUFFERED=1


### PR DESCRIPTION
This pull request enhances the Docker-based development workflow by introducing a more robust and flexible set of Docker services for development, testing, and production, along with improved documentation. The changes make it easier to spin up environments tailored for different use cases, add essential network and debugging tools to the sandbox, and clarify how to use each environment.

**Docker service improvements:**

* Added a new `test` service to `docker-compose.yml` for running tests with pytest and related tools, providing a dedicated environment for automated testing.
* Updated the `sandbox` service to include essential network and debugging tools (such as `netcat`, `tcpdump`, `ping`, `lsof`, etc.) for interactive development and troubleshooting.
* Refactored the `monix` service to be run only on demand (with explicit commands), and added Docker Compose profiles to separate production from development/test environments.

**Documentation updates:**

* Expanded the `README.md` with detailed instructions and examples for using the new Docker services, including quick commands for common workflows and explanations of each environment's purpose.