### PR TITLE
Refactor: Separate monix-linux from monix-web architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,48 @@ Intrusion Monitoring & Defense for Linux Servers
 
 Monix is an open-source host-level security tool that provides real-time threat monitoring, connection intelligence, and behavior-based attack detection for modern Linux servers.
 
+## Products
+
+Monix consists of **2 separate products**:
+
+### 1. monix-linux 
+
+A CLI tool for Linux server security monitoring and intrusion detection.
+
+**Features:**
+- Real-time connection monitoring
+- Threat detection (SYN floods, port scans, high connection counts)
+- GeoIP intelligence
+- Process tracking
+- Security scanning
+- Terminal-based dashboard (`--watch`)
+- Clean CLI interface
+
+### 2. monix-web
+
+A separate, independently deployed Next.js web application for web security analysis.
+
+**Features:**
+- URL security scanning
+- SSL certificate validation
+- DNS record analysis
+- Security headers assessment
+- Port scanning
+- Technology stack detection
+- Geographic intelligence
+
+**Note:** monix-web uses monix-core (shared from this repository) but is deployed as a separate product. It is NOT part of this CLI tool.
+
 ## Features
 
+This repository (monix-linux) provides:
 - Real-time connection monitoring
 - Threat detection (SYN floods, port scans, high connection counts)
 - GeoIP intelligence
 - Process tracking
 - Security scanning
 - Clean CLI interface
-- **monix-web <url>** (Instant CLI web security analysis)
-- Live dashboard UI
-- **Web Security Analyzer** (Modern Next.js interface)
-- **Comprehensive URL Scanning** (SSL, DNS, Headers, Ports, Cookies)
+- Live terminal dashboard (`--watch`)
 
 ## Quick Start
 
@@ -53,53 +83,8 @@ monix --alerts
 # Security scan
 monix --scan
 monix scan --deep
-
-# Open web interface
-monix --web
-# or
-monix web
-
-# CLI Web Analysis
-monix-web dineshkorkonda.in
-# or
-monix web mycrux.in
 ```
 
-
-### Web Interface
-
-Monix includes a comprehensive web-based interface with two main features:
-
-#### 1. Server Dashboard (`/monix`)
-
-Real-time monitoring dashboard showing:
-- **System Statistics**: CPU, memory, disk usage, network I/O, uptime
-- **Active Connections**: Live network connections with geo-location
-- **Security Alerts**: Real-time threat detection alerts
-- **Traffic Analysis**: Web traffic patterns and suspicious IP detection
-
-**Quick Start**:
-```bash
-# Start API server and open dashboard
-monix --web
-
-# Or manually:
-python api/server.py  # In one terminal
-cd web && npm run dev -p 3500  # In another terminal
-# Then visit http://localhost:3500/monix
-```
-
-#### 2. URL Security Analyzer (`/`)
-
-Modern security scanner for analyzing URLs and web applications:
-- SSL certificate validation
-- DNS record analysis
-- Security headers assessment
-- Port scanning
-- Technology stack detection
-- Geographic intelligence
-
-**Access**: Visit `http://localhost:3500` (or your server IP)
 
 ## Commands
 
@@ -111,7 +96,6 @@ Modern security scanner for analyzing URLs and web applications:
 | `--connections` / `-c` | List active connections |
 | `--alerts` / `-a` | Show security alerts |
 | `--scan` | Security scan |
-| `--web` | Open web interface (starts API server and opens browser) |
 
 ## Options
 
@@ -128,10 +112,6 @@ monix watch --refresh 5
 
 # Deep security scan
 monix scan --deep
-
-# Web interface options
-monix web --port 3030 --nextjs-port 3500
-monix web --no-open  # Don't open browser automatically
 ```
 
 ## Example Output
@@ -144,35 +124,9 @@ monix web --no-open  # Don't open browser automatically
 [2025-12-28 00:15:02] INFO: Status: SECURE | Host: my-server
 ```
 
-## Project Structure
-
-```
-monix/
-├── core/              # Core logic modules
-│   ├── collectors/    # Data collection (connections, system stats)
-│   ├── analyzers/    # Analysis and threat detection
-│   ├── scanners/     # Security scanning (system checks, web analysis)
-│   └── monitoring/   # Monitoring engine and state management
-├── utils/             # Utilities (logger, display, geo, network, processes)
-├── cli/               # CLI commands and UI
-│   ├── commands/     # CLI commands (monitor, status, watch, web, etc.)
-│   └── ui.py         # Terminal-based watch dashboard UI
-├── api/               # Flask REST API for web interface
-├── web/               # Next.js frontend application
-│   └── src/
-│       ├── app/
-│       │   ├── page.tsx      # URL Analyzer (home page)
-│       │   └── web/
-│       │       └── page.tsx  # Server Dashboard
-│       └── components/       # React components
-├── app.py             # Compatibility checker
-├── pyproject.toml
-└── README.md
-```
-
 ## Security Checks
 
-The `scan --deep` command and Web UI perform:
+The `scan --deep` command performs:
 
 | Check | Description |
 |-------|-------------|
@@ -197,3 +151,5 @@ The `scan --deep` command and Web UI perform:
 ## License
 
 MIT License
+
+- Developed by dineshkorukonda.in

--- a/cli/commands/web.py
+++ b/cli/commands/web.py
@@ -1,14 +1,15 @@
 """
-Web interface launcher command for Monix.
+CLI web security analysis command for Monix.
 
-This command starts the Monix web interface by:
-1. Starting the Flask API server
-2. Opening the web interface in the default browser
-3. Optionally starting the Next.js dev server if needed
+This command performs URL security analysis from the terminal.
+It uses the monix-core analysis engine but does NOT start any web servers.
+
+Note: The monix-web Next.js application is a separate, independently
+deployed product that uses monix-core. It is NOT started from this CLI.
 
 Technical Rationale:
-    Providing a unified CLI command to launch the web interface improves
-    user experience and ensures proper initialization of all services.
+    CLI-based URL analysis provides quick security checks without requiring
+    a web interface. The web dashboard is a separate product.
 """
 
 import os
@@ -249,83 +250,18 @@ def start_nextjs_server(port: int = 3500) -> subprocess.Popen:
         return None
 
 
-def run(port: int = 3030, nextjs_port: int = 3500, auto_open: bool = True):
-    """
-    Launch the Monix web interface.
-    
-    Args:
-        port: Port for the Flask API server (default: 3030)
-        nextjs_port: Port for the Next.js frontend (default: 3500)
-        auto_open: Whether to automatically open the browser
-    """
-    print(f"{C.CYAN}Monix Web Interface{C.RESET}")
-    print(f"{C.DIM}{'=' * 50}{C.RESET}")
-    
-    # Check if Flask is installed
-    if not check_flask_installed():
-        print(f"{C.RED}Error: Flask is not installed.{C.RESET}")
-        print(f"{C.YELLOW}Please install dependencies:{C.RESET}")
-        print(f"{C.CYAN}  pip install -r requirements.txt{C.RESET}")
-        sys.exit(1)
-    
-    # Check if API port is available
-    api_running = check_port_in_use(port)
-    if api_running:
-        print(f"{C.YELLOW}API server already running on port {port}{C.RESET}")
-    else:
-        print(f"{C.GREEN}Starting API server on port {port}...{C.RESET}")
-        api_thread = start_api_server(port)
-        time.sleep(3)  # Give server time to start
-    
-    # Check if Next.js is already running
-    nextjs_running = check_port_in_use(nextjs_port)
-    nextjs_process = None
-    
-    if nextjs_running:
-        print(f"{C.YELLOW}Next.js server already running on port {nextjs_port}{C.RESET}")
-    else:
-        print(f"{C.GREEN}Starting Next.js server on port {nextjs_port} (binding to 0.0.0.0)...{C.RESET}")
-        nextjs_process = start_nextjs_server(nextjs_port)
-        if nextjs_process:
-            time.sleep(5)  # Give Next.js time to start
-    
-    # Get local IP
-    local_ip = get_local_ip()
-    
-    # Determine web URL
-    web_url = f"http://{local_ip}:{nextjs_port}/monix"
-    api_url = f"http://{local_ip}:{port}"
-    
-    print(f"{C.DIM}{'=' * 50}{C.RESET}")
-    print(f"{C.GREEN}API Server: {C.BOLD}{api_url}{C.RESET}")
-    print(f"{C.GREEN}Web Interface: {C.BOLD}{web_url}{C.RESET}")
-    print(f"{C.DIM}{'=' * 50}{C.RESET}")
-    print(f"{C.CYAN}Press Ctrl+C to stop{C.RESET}")
-    
-    # Open browser if requested
-    if auto_open:
-        try:
-            time.sleep(2)  # Give servers a moment to be ready
-            webbrowser.open(web_url)
-            print(f"{C.GREEN}Opened browser to {web_url}{C.RESET}")
-        except Exception as e:
-            print(f"{C.YELLOW}Could not open browser automatically: {e}{C.RESET}")
-            print(f"{C.CYAN}Please open {web_url} manually{C.RESET}")
-    
-    # Keep the process alive
-    try:
-        while True:
-            time.sleep(1)
-            # Check if Next.js process is still alive
-            if nextjs_process and nextjs_process.poll() is not None:
-                print(f"{C.RED}Next.js server stopped unexpectedly{C.RESET}")
-                break
-    except KeyboardInterrupt:
-        print(f"\n{C.YELLOW}Shutting down...{C.RESET}")
-        if nextjs_process:
-            nextjs_process.terminate()
-            try:
-                nextjs_process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                nextjs_process.kill()
-        sys.exit(0)
+# NOTE: This function is commented out because monix-web is a separate,
+# independently deployed Next.js application. The CLI tool (monix-linux)
+# should NOT start web servers. This code is kept for reference only.
+#
+# def run(port: int = 3030, nextjs_port: int = 3500, auto_open: bool = True):
+#     """
+#     [DISABLED] Launch the Monix web interface.
+#     
+#     This function is disabled because monix-web is a separate product.
+#     The web dashboard should be deployed independently, not started from CLI.
+#     """
+#     print(f"{C.RED}ERROR: Web interface launcher is disabled.{C.RESET}")
+#     print(f"{C.YELLOW}monix-web is a separate, independently deployed product.{C.RESET}")
+#     print(f"{C.CYAN}Use 'monix web <url>' for CLI URL analysis instead.{C.RESET}")
+#     sys.exit(1)

--- a/cli/main.py
+++ b/cli/main.py
@@ -13,10 +13,9 @@ from cli.commands import monitor, status, watch, connections, alerts, scan, traf
 @click.option('--alerts', '-a', 'run_alerts', is_flag=True, help='Show security alerts')
 @click.option('--scan', 'run_scan', is_flag=True, help='Quick security scan')
 @click.option('--traffic', '-t', 'run_traffic', is_flag=True, help='Analyze suspicious web traffic')
-@click.option('--web', 'run_web', is_flag=True, help='Open web interface')
 @click.option('--json', 'output_json', is_flag=True, help='Output in JSON format')
 @click.pass_context
-def cli(ctx, version, run_monitor, run_status, run_watch, run_connections, run_alerts, run_scan, run_traffic, run_web, output_json):
+def cli(ctx, version, run_monitor, run_status, run_watch, run_connections, run_alerts, run_scan, run_traffic, output_json):
     if version:
         click.echo(f"monix v{__version__}")
         return
@@ -47,10 +46,6 @@ def cli(ctx, version, run_monitor, run_status, run_watch, run_connections, run_a
     
     if run_traffic:
         traffic.run(output_json=output_json)
-        return
-    
-    if run_web:
-        web.run()
         return
     
     if ctx.invoked_subcommand is None:
@@ -96,32 +91,27 @@ def traffic_cmd(log, window, limit, output_json):
     traffic.run(log_path=log, window=window, limit=limit, output_json=output_json)
 
 @cli.command('web')
-@click.argument('url', required=False)
-@click.option('--port', '-p', default=3030, help='API server port (default: 3030)')
-@click.option('--nextjs-port', '-n', default=3500, help='Next.js frontend port (default: 3500)')
-@click.option('--no-open', is_flag=True, help='Do not open browser automatically')
-def web_cmd(url, port, nextjs_port, no_open):
-    if url:
-        web.run_analysis(url)
-    else:
-        web.run(port=port, nextjs_port=nextjs_port, auto_open=not no_open)
+@click.argument('url', required=True)
+def web_cmd(url):
+    """Analyze a URL for security threats (CLI only)."""
+    web.run_analysis(url)
 
 def monix_web_main():
-    """Standalone entry point for monix-web <url>"""
+    """Standalone entry point for monix-web <url> - CLI URL analysis only."""
     import sys
-    # Handle the case where someone might pass arguments
+    from cli.commands import web
+    
     if len(sys.argv) > 1:
         url = sys.argv[1]
-        # If it looks like an option, just run the default web command
-        if url.startswith('-'):
-            from cli.commands import web
-            web.run()
-        else:
-            from cli.commands import web
+        # Only do URL analysis, don't start web server
+        if not url.startswith('-'):
             web.run_analysis(url)
+        else:
+            print("Usage: monix-web <url>")
+            print("Example: monix-web https://example.com")
     else:
-        from cli.commands import web
-        web.run()
+        print("Usage: monix-web <url>")
+        print("Example: monix-web https://example.com")
 
 def main():
     cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ Repository = "https://github.com/dinexh/monix"
 Issues = "https://github.com/dinexh/monix/issues"
 
 [tool.setuptools.packages.find]
-include = ["cli*", "core*", "shared*", "utils*", "dashboard*"]
+include = ["cli*", "core*", "utils*"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
- Remove --web flag that started local web servers
- Update monix web command to only do CLI URL analysis (disabled server launcher)
- Remove monix-package references from codebase
- Update README to clearly document 2 separate products:
  * monix-linux: CLI tool for Linux server security monitoring
  * monix-web: Separate Next.js app for web security analysis
- Clean up pyproject.toml to remove unused package references
- Clarify that monix-web is independently deployed, not part of CLI tool