### PR TITLE
feat: add report expiry automation

### DIFF
--- a/api/collectors/connection.py
+++ b/api/collectors/connection.py
@@ -75,7 +75,7 @@ def collect_connections():
                     try:
                         p = psutil.Process(c.pid)
                         conn["pname"] = p.name()
-                    except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    except Exception:
                         pass
                 
                 if conn["remote_ip"] not in ["127.0.0.1", "0.0.0.0", "::1", "::", ""]:

--- a/core/reports/management/__init__.py
+++ b/core/reports/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands package for the reports app."""

--- a/core/reports/management/commands/__init__.py
+++ b/core/reports/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Custom Django management commands for the reports app."""

--- a/core/reports/management/commands/expire_reports.py
+++ b/core/reports/management/commands/expire_reports.py
@@ -1,0 +1,19 @@
+"""Mark past-due reports as expired."""
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from reports.models import Report
+
+
+class Command(BaseCommand):
+    help = "Mark all past-due reports as expired."
+
+    def handle(self, *args, **options):
+        expired_count = (
+            Report.objects.filter(is_expired=False, expires_at__lte=timezone.now())
+            .update(is_expired=True)
+        )
+        self.stdout.write(
+            self.style.SUCCESS(f"Marked {expired_count} report(s) as expired.")
+        )

--- a/tests/test_collectors_connection.py
+++ b/tests/test_collectors_connection.py
@@ -1,0 +1,124 @@
+"""Tests for api.collectors.connection."""
+
+from types import SimpleNamespace
+from unittest.mock import mock_open, patch
+
+from api.collectors.connection import collect_connections
+
+
+class TestCollectConnectionsProcfs:
+    @patch("api.collectors.connection.reverse_dns", return_value="example.com")
+    @patch("api.collectors.connection.geo_lookup", return_value="US")
+    @patch("api.collectors.connection.get_process_map", return_value={("127.0.0.1", 53): (123, "dnsmasq")})
+    @patch("api.collectors.connection.hex_port")
+    @patch("api.collectors.connection.hex_ip")
+    def test_reads_procfs_connections(
+        self,
+        mock_hex_ip,
+        mock_hex_port,
+        _mock_process_map,
+        mock_geo,
+        mock_dns,
+    ):
+        line = "0: 0100007F:0035 08080808:01BB 01 00000000:00000000 00:00000000 00000000 0 0 0 0 0 0 0 0\n"
+        mock_hex_ip.side_effect = ["127.0.0.1", "8.8.8.8"]
+        mock_hex_port.side_effect = [53, 443]
+
+        with patch("api.collectors.connection.os.path.exists", side_effect=lambda path: path == "/proc/net/tcp"):
+            with patch("builtins.open", mock_open(read_data=f"header\n{line}")):
+                connections = collect_connections()
+
+        assert len(connections) == 1
+        assert connections[0]["local_ip"] == "127.0.0.1"
+        assert connections[0]["remote_ip"] == "8.8.8.8"
+        assert connections[0]["state"] == "ESTABLISHED"
+        assert connections[0]["pid"] == 123
+        assert connections[0]["pname"] == "dnsmasq"
+        assert connections[0]["geo"] == "US"
+        assert connections[0]["domain"] == "example.com"
+        mock_geo.assert_called_once_with("8.8.8.8")
+        mock_dns.assert_called_once_with("8.8.8.8")
+
+    @patch("api.collectors.connection.get_process_map", return_value={})
+    @patch("api.collectors.connection.hex_port", side_effect=[80, 0])
+    @patch("api.collectors.connection.hex_ip", side_effect=["127.0.0.1", "0.0.0.0"])
+    def test_skips_geo_lookup_for_local_or_unspecified_ips(
+        self,
+        _mock_hex_ip,
+        _mock_hex_port,
+        _mock_process_map,
+    ):
+        line = "0: 0100007F:0050 00000000:0000 01 00000000:00000000 00:00000000 00000000 0 0 0 0 0 0 0 0\n"
+
+        with patch("api.collectors.connection.os.path.exists", side_effect=lambda path: path == "/proc/net/tcp"):
+            with patch("builtins.open", mock_open(read_data=f"header\n{line}")):
+                with patch("api.collectors.connection.geo_lookup") as mock_geo:
+                    with patch("api.collectors.connection.reverse_dns") as mock_dns:
+                        connections = collect_connections()
+
+        assert connections[0]["geo"] == ""
+        assert connections[0]["domain"] == ""
+        mock_geo.assert_not_called()
+        mock_dns.assert_not_called()
+
+    @patch("api.collectors.connection.get_process_map", return_value={})
+    def test_procfs_read_errors_are_ignored(self, _mock_process_map):
+        with patch("api.collectors.connection.os.path.exists", side_effect=lambda path: path == "/proc/net/tcp"):
+            with patch("builtins.open", side_effect=OSError("boom")):
+                assert collect_connections() == []
+
+
+class TestCollectConnectionsPsutilFallback:
+    @patch("api.collectors.connection.reverse_dns", return_value="dns.google")
+    @patch("api.collectors.connection.geo_lookup", return_value="US")
+    @patch("api.collectors.connection.psutil.Process")
+    @patch("api.collectors.connection.psutil.net_connections")
+    def test_falls_back_to_psutil_when_procfs_missing(
+        self,
+        mock_net_connections,
+        mock_process,
+        mock_geo,
+        mock_dns,
+    ):
+        mock_process.return_value.name.return_value = "python"
+        mock_net_connections.return_value = [
+            SimpleNamespace(
+                laddr=SimpleNamespace(ip="10.0.0.5", port=5000),
+                raddr=SimpleNamespace(ip="8.8.8.8", port=443),
+                status="ESTABLISHED",
+                pid=999,
+            )
+        ]
+
+        with patch("api.collectors.connection.os.path.exists", return_value=False):
+            connections = collect_connections()
+
+        assert len(connections) == 1
+        assert connections[0]["pname"] == "python"
+        assert connections[0]["geo"] == "US"
+        assert connections[0]["domain"] == "dns.google"
+        mock_geo.assert_called_once_with("8.8.8.8")
+        mock_dns.assert_called_once_with("8.8.8.8")
+
+    @patch("api.collectors.connection.psutil.Process")
+    @patch("api.collectors.connection.psutil.net_connections")
+    def test_psutil_process_lookup_failure_is_non_fatal(self, mock_net_connections, mock_process):
+        mock_process.side_effect = Exception("no process")
+        mock_net_connections.return_value = [
+            SimpleNamespace(
+                laddr=SimpleNamespace(ip="10.0.0.5", port=5000),
+                raddr=SimpleNamespace(ip="", port=0),
+                status="ESTABLISHED",
+                pid=999,
+            )
+        ]
+
+        with patch("api.collectors.connection.os.path.exists", return_value=False):
+            connections = collect_connections()
+
+        assert connections[0]["pname"] == ""
+
+    @patch("api.collectors.connection.psutil.net_connections", side_effect=RuntimeError("fail"))
+    def test_psutil_failure_returns_empty_list(self, _mock_connections):
+        with patch("api.collectors.connection.os.path.exists", return_value=False):
+            assert collect_connections() == []

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -43,6 +43,8 @@ class TestSaveScanWithDatabase:
         """save_scan returns a valid UUID string when the database write succeeds."""
         session_mock = self._make_session_mock()
         session_factory = MagicMock(return_value=session_mock)
+        added_objects = []
+        session_mock.add.side_effect = added_objects.append
 
         with patch("api.db._SessionLocal", session_factory):
             from api.db import save_scan
@@ -53,6 +55,10 @@ class TestSaveScanWithDatabase:
         # Must be a valid UUID
         parsed = uuid.UUID(result)
         assert str(parsed) == result
+        scan_record, report_record = added_objects
+        ttl = report_record.expires_at - scan_record.created_at
+        assert ttl.days == 30
+        assert report_record.is_expired is False
 
     def test_clamps_score_below_zero(self):
         """Scores below 0 are clamped to 0 before storing."""

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -1,0 +1,103 @@
+"""
+Tests for Django report expiry behavior and management commands.
+"""
+
+import os
+import sys
+from datetime import timedelta
+from io import StringIO
+
+import django
+
+_CORE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "core")
+if _CORE_DIR not in sys.path:
+    sys.path.insert(0, _CORE_DIR)
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+from django.core.management import call_command  # noqa: E402
+from django.test import TestCase  # noqa: E402
+from django.utils import timezone  # noqa: E402
+
+from reports.models import Report, Scan  # noqa: E402
+
+
+def _make_scan(url="https://example.com", score=20, results=None):
+    return Scan.objects.create(url=url, score=score, results=results or {"status": "success"})
+
+
+def _make_report(scan, is_expired=False, expires_at=None):
+    return Report.objects.create(
+        scan=scan,
+        is_expired=is_expired,
+        expires_at=expires_at or (timezone.now() + timedelta(days=30)),
+    )
+
+
+class ReportModelTest(TestCase):
+    def test_report_string_includes_active_status(self):
+        scan = _make_scan()
+        report = _make_report(scan)
+
+        assert "active" in str(report)
+
+    def test_report_string_includes_expired_status(self):
+        scan = _make_scan()
+        report = _make_report(scan, is_expired=True)
+
+        assert "expired" in str(report)
+
+    def test_report_ordering_uses_newest_scan_first(self):
+        older_scan = _make_scan(url="https://older.example.com")
+        newer_scan = _make_scan(url="https://newer.example.com")
+
+        older_report = _make_report(older_scan)
+        newer_report = _make_report(newer_scan)
+
+        Scan.objects.filter(pk=older_scan.pk).update(
+            created_at=timezone.now() - timedelta(days=1)
+        )
+
+        ordered_ids = list(Report.objects.values_list("id", flat=True))
+        assert ordered_ids == [newer_report.id, older_report.id]
+
+
+class ExpireReportsCommandTest(TestCase):
+    def test_command_marks_only_past_due_reports_as_expired(self):
+        overdue_report = _make_report(
+            _make_scan(url="https://old.example.com"),
+            expires_at=timezone.now() - timedelta(days=1),
+        )
+        fresh_report = _make_report(
+            _make_scan(url="https://fresh.example.com"),
+            expires_at=timezone.now() + timedelta(days=10),
+        )
+        already_expired = _make_report(
+            _make_scan(url="https://expired.example.com"),
+            is_expired=True,
+            expires_at=timezone.now() - timedelta(days=2),
+        )
+
+        out = StringIO()
+        call_command("expire_reports", stdout=out)
+
+        overdue_report.refresh_from_db()
+        fresh_report.refresh_from_db()
+        already_expired.refresh_from_db()
+
+        assert overdue_report.is_expired is True
+        assert fresh_report.is_expired is False
+        assert already_expired.is_expired is True
+        assert "Marked 1 report(s) as expired." in out.getvalue()
+
+    def test_command_is_idempotent_when_nothing_is_due(self):
+        _make_report(
+            _make_scan(url="https://future.example.com"),
+            expires_at=timezone.now() + timedelta(days=7),
+        )
+
+        out = StringIO()
+        call_command("expire_reports", stdout=out)
+
+        assert "Marked 0 report(s) as expired." in out.getvalue()

--- a/tests/test_monitoring_engine.py
+++ b/tests/test_monitoring_engine.py
@@ -1,0 +1,45 @@
+"""Tests for api.monitoring.engine."""
+
+from unittest.mock import patch
+
+from api.monitoring import engine
+
+
+def _conn(remote_ip="8.8.8.8", local_port=80, state="ESTABLISHED"):
+    return {"remote_ip": remote_ip, "local_port": local_port, "state": state}
+
+
+class TestDetectAttacks:
+    @patch("api.monitoring.engine.state.add_alert")
+    @patch("api.monitoring.engine.time.time", return_value=100.0)
+    def test_detects_syn_flood_high_conn_and_port_scan(self, _mock_time, mock_add_alert):
+        engine.port_activity.clear()
+        conns = []
+        conns.extend([_conn(remote_ip="9.9.9.9", state="SYN_RECV") for _ in range(100)])
+        conns.extend([_conn(remote_ip="8.8.8.8", state="ESTABLISHED") for _ in range(50)])
+        conns.extend([_conn(remote_ip="7.7.7.7", state="ESTABLISHED", local_port=port) for port in range(1, 6)])
+
+        engine.detect_attacks(conns)
+
+        messages = [call.args[0] for call in mock_add_alert.call_args_list]
+        assert any("SYN_FLOOD from 9.9.9.9" in message for message in messages)
+        assert any("HIGH_CONN from 8.8.8.8" in message for message in messages)
+        assert any("PORT_SCAN from 7.7.7.7" in message for message in messages)
+
+    @patch("api.monitoring.engine.state.add_alert")
+    @patch("api.monitoring.engine.time.time", return_value=100.0)
+    def test_ignores_local_ips_for_port_scan_tracking(self, _mock_time, mock_add_alert):
+        engine.port_activity.clear()
+
+        engine.detect_attacks([_conn(remote_ip="127.0.0.1", local_port=port) for port in range(1, 10)])
+
+        mock_add_alert.assert_not_called()
+
+
+class TestStartMonitor:
+    @patch("api.monitoring.engine.Thread")
+    def test_start_monitor_starts_daemon_thread(self, mock_thread):
+        engine.start_monitor()
+
+        mock_thread.assert_called_once_with(target=engine.collector_loop, daemon=True)
+        mock_thread.return_value.start.assert_called_once()

--- a/tests/test_monitoring_state.py
+++ b/tests/test_monitoring_state.py
@@ -1,0 +1,55 @@
+"""Tests for api.monitoring.state."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from api.monitoring.state import GlobalState
+
+
+class TestGlobalState:
+    def test_snapshot_returns_copies(self):
+        state = GlobalState()
+        state.update_connections([{"id": 1}])
+        state.update_traffic({"total_requests": 3})
+        state.add_alert("hello")
+
+        connections, alerts = state.snapshot()
+        full_connections, full_alerts, traffic = state.full_snapshot()
+
+        connections.append({"id": 2})
+        alerts.append("extra")
+        traffic["total_requests"] = 0
+
+        assert len(state.connections) == 1
+        assert len(state.alerts) == 1
+        assert state.traffic_summary["total_requests"] == 3
+        assert len(full_connections) == 1
+        assert len(full_alerts) == 1
+
+    def test_add_alert_rate_limits_duplicate_keys(self):
+        state = GlobalState()
+        fixed_now = datetime(2026, 1, 1, 12, 0, 0)
+
+        with patch("api.monitoring.state.datetime") as mock_datetime:
+            mock_datetime.now.side_effect = [
+                fixed_now,
+                fixed_now + timedelta(seconds=30),
+                fixed_now + timedelta(seconds=61),
+            ]
+            state.add_alert("first", key="dup")
+            state.add_alert("second", key="dup")
+            state.add_alert("third", key="dup")
+
+        assert len(state.alerts) == 2
+        assert "third" in state.alerts[0]
+        assert "first" in state.alerts[1]
+
+    def test_add_alert_keeps_only_latest_20(self):
+        state = GlobalState()
+
+        for i in range(25):
+            state.add_alert(f"alert-{i}")
+
+        assert len(state.alerts) == 20
+        assert "alert-24" in state.alerts[0]
+        assert all("alert-0" not in alert for alert in state.alerts)

--- a/tests/test_scanners_security.py
+++ b/tests/test_scanners_security.py
@@ -1,0 +1,69 @@
+"""Tests for api.scanners.security."""
+
+from api.scanners.security import (
+    check_dangerous_ports,
+    check_listening_count,
+    check_outbound_suspicious,
+    check_sensitive_external,
+    check_ssh_port,
+    run_security_checks,
+)
+
+
+def _conn(**overrides):
+    base = {
+        "local_port": 80,
+        "remote_port": 443,
+        "remote_ip": "8.8.8.8",
+        "state": "ESTABLISHED",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSecurityChecks:
+    def test_run_security_checks_returns_all_checks(self):
+        results = run_security_checks([_conn()])
+        assert len(results) == 5
+        assert {item["name"] for item in results} == {
+            "SSH Port Check",
+            "Dangerous Ports",
+            "Listening Ports Count",
+            "External DB/Service Access",
+            "Suspicious Outbound",
+        }
+
+    def test_ssh_port_detects_default_listener(self):
+        result = check_ssh_port([_conn(local_port=22, state="LISTEN")])
+        assert result["passed"] is False
+
+    def test_dangerous_ports_lists_exposed_services(self):
+        result = check_dangerous_ports(
+            [_conn(local_port=21, state="LISTEN"), _conn(local_port=3389, state="LISTEN")]
+        )
+        assert result["passed"] is False
+        assert "FTP:21" in result["details"]
+        assert "RDP:3389" in result["details"]
+
+    def test_listening_count_fails_at_50(self):
+        result = check_listening_count([_conn(state="LISTEN") for _ in range(50)])
+        assert result["passed"] is False
+        assert "50 ports listening" in result["details"]
+
+    def test_sensitive_external_ignores_local_ips(self):
+        result = check_sensitive_external(
+            [_conn(local_port=5432, state="ESTABLISHED", remote_ip="127.0.0.1")]
+        )
+        assert result["passed"] is True
+
+    def test_sensitive_external_flags_remote_sensitive_access(self):
+        result = check_sensitive_external(
+            [_conn(local_port=5432, state="ESTABLISHED", remote_ip="9.9.9.9")]
+        )
+        assert result["passed"] is False
+        assert "9.9.9.9" in result["details"]
+
+    def test_outbound_suspicious_flags_known_ports(self):
+        result = check_outbound_suspicious([_conn(remote_port=31337, remote_ip="5.5.5.5")])
+        assert result["passed"] is False
+        assert "5.5.5.5:31337" in result["details"]


### PR DESCRIPTION
This pull request introduces significant improvements to testing coverage, robustness, and maintainability for several core modules, including the collectors, monitoring, Django management, and security scanners. It adds comprehensive unit tests for previously untested modules, implements a new Django management command for expiring reports, and makes minor robustness improvements to exception handling.

**Testing improvements:**

- Added comprehensive unit tests for `api.collectors.connection`, covering both `/proc` and `psutil` backends, local IP handling, and error scenarios.
- Introduced tests for `api.monitoring.engine` and `api.monitoring.state`, including attack detection logic, alert rate-limiting, and state snapshotting. [[1]](diffhunk://#diff-05a4dc679e6a2e93fdab07af91d10e29aeb0e8b47a30ea7bcdff8b784af7ba35R1-R45) [[2]](diffhunk://#diff-a3adeab4b2aab738a3a44f09535b6a87c2d00bc17873dc39279e507cdcc28fb8R1-R55)
- Added tests for `api.scanners.security`, ensuring all security checks are exercised and their logic is verified.
- Added Django model and management command tests for report expiry logic, including idempotency and string representations.

**New Django management command:**

- Implemented `expire_reports` management command to mark past-due reports as expired, with accompanying help text and package docstrings. [[1]](diffhunk://#diff-738eb5c6bc6650ca11ecbfcda0239b7252bd0c34828b4721302e507ea6129ae3R1-R19) [[2]](diffhunk://#diff-2495853c45692dcb9efa0476d6eca515d30fc82c1685007d687b5d668ef22ab8R1) [[3]](diffhunk://#diff-13097cced932395431e6f41aceebbad332399725225073821d8f4c41166dec43R1)

**Robustness improvements:**

- Broadened exception handling in `collect_connections` to catch all exceptions (not just `psutil.NoSuchProcess` and `psutil.AccessDenied`) when retrieving process names, preventing unexpected crashes.

**Test enhancements for existing code:**

- Improved `test_returns_uuid_string_on_success` to verify report expiry fields and TTL calculation in database tests. [[1]](diffhunk://#diff-b5f450a5ce32582aed8932f7ef3831dfb48dc85692413ed492fad459f8e8ac8cR46-R47) [[2]](diffhunk://#diff-b5f450a5ce32582aed8932f7ef3831dfb48dc85692413ed492fad459f8e8ac8cR58-R61)Increase backend coverage for collectors, monitoring, and security checks.