### PR TITLE
Next.js serverless API: Supabase data layer, GSC/Cloudflare, scans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,10 +25,19 @@ DEBUG=True
 # SUPABASE_JWKS_URL=https://<project-ref>.supabase.co/auth/v1/.well-known/jwks.json
 # SUPABASE_JWT_AUD=authenticated
 
-# Next.js server (Route Handlers): verify Supabase JWTs before proxying to Django.
+# Next.js server (Route Handlers): verify Supabase JWTs and call Supabase Postgres.
 # Set the same SUPABASE_URL / JWKS / audience as Django. For local HS256 tests only:
 # SUPABASE_JWT_SECRET=...
 # MONIX_VERIFY_SUPABASE_JWT=false  # optional: skip verification (do not use in production)
+#
+# Service role key for server-side Supabase (targets, scans, credentials). Never expose to the browser.
+# SUPABASE_SERVICE_ROLE_KEY=
+#
+# Public site URL for server-side fetch during SSR (e.g. https://app.example.com).
+# NEXT_PUBLIC_SITE_URL=http://localhost:3000
+#
+# Optional: HS256 secret for short-lived GSC OAuth state JWTs (defaults to a hash of GOOGLE_REFRESH_TOKEN_FERNET_KEY or SUPABASE_SERVICE_ROLE_KEY).
+# MONIX_GSC_STATE_SECRET=
 
 # Canonical public URL of Django (scheme + host + port, no trailing slash).
 # Used to build Google OAuth redirect_uris. In DEBUG, defaults to
@@ -56,9 +65,10 @@ AXES_COOLOFF_TIME=1
 #
 #   http://localhost:8000/api/auth/google/callback/
 #
-# Set GOOGLE_REDIRECT_URI (or legacy alias GOOGLE_REDIRECT_URL) to the same URL.
-# Django routes that path: GSC responses include webmasters scope; sign-in
-# does not (see api_auth_google_callback_compat).
+# Set GOOGLE_REDIRECT_URI (or legacy alias GOOGLE_REDIRECT_URL) to the OAuth callback URL.
+# For the Next.js-only stack, use your app origin, e.g.:
+#   http://localhost:3000/api/gsc/callback
+# Legacy Django deployments used http://localhost:8000/api/auth/google/callback/
 #
 # Optional "Authorized JavaScript origins" for local dev:
 #   http://localhost:3000   http://localhost:8000

--- a/supabase/migrations/000002_monix_user_names.sql
+++ b/supabase/migrations/000002_monix_user_names.sql
@@ -1,0 +1,3 @@
+alter table public.monix_users
+  add column if not exists first_name text not null default '',
+  add column if not exists last_name text not null default '';

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -10,6 +10,7 @@
         "@vercel/speed-insights": "^1.3.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fernet": "^0.3.3",
         "framer-motion": "^12.35.2",
         "jose": "^5.10.0",
         "lucide-react": "^1.7.0",
@@ -391,6 +392,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
@@ -428,6 +431,8 @@
     "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "fernet": ["fernet@0.3.3", "", { "dependencies": { "crypto-js": "~4.2.0", "urlsafe-base64": "1.0.0" } }, "sha512-DvvqouVhv3VCor83wkQbSycekYUKDRQ1IKqcInaF5n5BSKgWBVfYLbSf7RRxojwQO0DZySiz5MlM2vO4MG3SUg=="],
 
     "framer-motion": ["framer-motion@12.35.2", "", { "dependencies": { "motion-dom": "^12.35.2", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-dhfuEMaNo0hc+AEqyHiIfiJRNb9U9UQutE9FoKm5pjf7CMitp9xPEF1iWZihR1q86LBmo6EJ7S8cN8QXEy49AA=="],
 
@@ -568,6 +573,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "urlsafe-base64": ["urlsafe-base64@1.0.0", "", {}, "sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "@vercel/speed-insights": "^1.3.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fernet": "^0.3.3",
     "framer-motion": "^12.35.2",
     "jose": "^5.10.0",
     "lucide-react": "^1.7.0",

--- a/web/src/app/api/alerts/route.ts
+++ b/web/src/app/api/alerts/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ status: "success", alerts: [], count: 0 });
+}

--- a/web/src/app/api/analyze-url/route.ts
+++ b/web/src/app/api/analyze-url/route.ts
@@ -1,0 +1,45 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { runFullUrlAnalysis } from "@/server/scan/analyze-url-engine";
+
+export async function POST(request: NextRequest) {
+  try {
+    let body: Record<string, unknown> = {};
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json(
+        { status: "error", error: "Invalid JSON body" },
+        { status: 400 },
+      );
+    }
+    const url = String(body.url ?? "").trim();
+    if (!url) {
+      return NextResponse.json(
+        { status: "error", error: "Missing 'url' in request body" },
+        { status: 400 },
+      );
+    }
+    const fullScan =
+      request.nextUrl.searchParams.get("full")?.toLowerCase() === "true";
+    const includePortScan = Boolean(body.include_port_scan ?? fullScan);
+    const includeMetadata = Boolean(body.include_metadata ?? fullScan);
+    let includePerformance = Boolean(body.include_performance ?? false);
+    if (fullScan) includePerformance = true;
+    const result = await runFullUrlAnalysis({
+      url,
+      fullScan,
+      includePortScan,
+      includeMetadata,
+      includePerformance,
+      targetId: null,
+      persist: true,
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Internal error";
+    return NextResponse.json(
+      { status: "error", error: message },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/auth/account/route.ts
+++ b/web/src/app/api/auth/account/route.ts
@@ -1,0 +1,21 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { requireSupabaseAuth } from "@/server/auth/policy";
+import { deleteUserData, requireUserSub } from "@/server/db/monix-data";
+import { getSupabaseAdmin } from "@/server/db/supabase-admin";
+import { handleRouteError } from "@/server/transport/http";
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    await deleteUserData(sub);
+    try {
+      await getSupabaseAdmin().auth.admin.deleteUser(sub);
+    } catch {
+      /* Supabase may reject if user already gone */
+    }
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { requireSupabaseAuth } from "@/server/auth/policy";
+import { emailFromBearer } from "@/server/db/monix-auth-email";
+import { buildMeResponse, requireUserSub } from "@/server/db/monix-data";
+import { handleRouteError } from "@/server/transport/http";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    const email = await emailFromBearer(token);
+    const payload = await buildMeResponse(sub, email);
+    return NextResponse.json(payload);
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/web/src/app/api/connections/route.ts
+++ b/web/src/app/api/connections/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ status: "success", connections: [], count: 0 });
+}

--- a/web/src/app/api/dashboard/route.ts
+++ b/web/src/app/api/dashboard/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({
+    connections: [],
+    alerts: [],
+    system_stats: {
+      cpu_percent: 0,
+      memory_percent: 0,
+      disk_percent: 0,
+      network_sent: 0,
+      network_recv: 0,
+      uptime: 0,
+      load_avg: [0, 0, 0],
+      process_count: 0,
+    },
+    traffic_summary: {
+      total_requests: 0,
+      unique_ips: 0,
+      total_404s: 0,
+      high_risk_hits: 0,
+      suspicious_ips: [],
+    },
+  });
+}

--- a/web/src/app/api/gsc/connect/route.ts
+++ b/web/src/app/api/gsc/connect/route.ts
@@ -6,9 +6,12 @@ import { handleRouteError } from "@/server/transport/http";
 
 export async function GET(request: NextRequest) {
   try {
-    const { token } = await requireSupabaseAuth(request);
+    const { token, sub } = await requireSupabaseAuth(request);
     const payload =
-      await buildIntegrationServices().gsc.getConnectAuthorizationUrl(token);
+      await buildIntegrationServices().gsc.getConnectAuthorizationUrl({
+        bearerToken: token,
+        supabaseUserId: sub,
+      });
     return NextResponse.json(asJson(payload));
   } catch (error) {
     return handleRouteError(error);

--- a/web/src/app/api/health/route.ts
+++ b/web/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ status: "ok", service: "monix-api" });
+}

--- a/web/src/app/api/me/reports/[reportId]/route.ts
+++ b/web/src/app/api/me/reports/[reportId]/route.ts
@@ -1,0 +1,23 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { requireSupabaseAuth } from "@/server/auth/policy";
+import {
+  getReportEnvelopeForUser,
+  requireUserSub,
+} from "@/server/db/monix-data";
+import { handleRouteError } from "@/server/transport/http";
+
+/** Authenticated report fetch (owner or URL-matched orphan). */
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ reportId: string }> },
+) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    const { reportId } = await ctx.params;
+    const payload = await getReportEnvelopeForUser(reportId, sub);
+    return NextResponse.json(payload);
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/web/src/app/api/reports/[reportId]/route.ts
+++ b/web/src/app/api/reports/[reportId]/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getReportEnvelopePublic } from "@/server/db/monix-data";
+import { handleRouteError } from "@/server/transport/http";
+
+/** Shareable report payload (matches legacy Django `report_detail`). */
+export async function GET(
+  _request: Request,
+  ctx: { params: Promise<{ reportId: string }> },
+) {
+  try {
+    const { reportId } = await ctx.params;
+    const payload = await getReportEnvelopePublic(reportId);
+    return NextResponse.json(payload);
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/web/src/app/api/scans/locations/route.ts
+++ b/web/src/app/api/scans/locations/route.ts
@@ -1,0 +1,15 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { requireSupabaseAuth } from "@/server/auth/policy";
+import { requireUserSub, scanLocationsForUser } from "@/server/db/monix-data";
+import { handleRouteError } from "@/server/transport/http";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    const data = await scanLocationsForUser(sub);
+    return NextResponse.json(data);
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/web/src/app/api/scans/route.ts
+++ b/web/src/app/api/scans/route.ts
@@ -1,0 +1,15 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { requireSupabaseAuth } from "@/server/auth/policy";
+import { listScansForUser, requireUserSub } from "@/server/db/monix-data";
+import { handleRouteError } from "@/server/transport/http";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    const data = await listScansForUser(sub);
+    return NextResponse.json(data);
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/web/src/app/api/scans/run/route.ts
+++ b/web/src/app/api/scans/run/route.ts
@@ -1,0 +1,65 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { requireSupabaseAuth } from "@/server/auth/policy";
+import { requireUserSub } from "@/server/db/monix-data";
+import { getSupabaseAdmin } from "@/server/db/supabase-admin";
+import { runFullUrlAnalysis } from "@/server/scan/analyze-url-engine";
+import { handleRouteError } from "@/server/transport/http";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    let body: Record<string, unknown> = {};
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid JSON body." },
+        { status: 400 },
+      );
+    }
+    const url = String(body.url ?? "").trim();
+    if (!url) {
+      return NextResponse.json(
+        { error: "Missing 'url' in request body" },
+        { status: 400 },
+      );
+    }
+    let targetId: string | null = null;
+    const tidRaw = body.target_id;
+    if (tidRaw != null && String(tidRaw).trim()) {
+      const tid = String(tidRaw).trim();
+      const { data } = await getSupabaseAdmin()
+        .from("monix_targets")
+        .select("id")
+        .eq("id", tid)
+        .eq("owner_id", sub)
+        .maybeSingle();
+      if (!data) {
+        return NextResponse.json(
+          { error: "Target not found." },
+          { status: 404 },
+        );
+      }
+      targetId = tid;
+    }
+    const fullScan =
+      request.nextUrl.searchParams.get("full")?.toLowerCase() === "true";
+    const includePortScan = Boolean(body.include_port_scan ?? fullScan);
+    const includeMetadata = Boolean(body.include_metadata ?? fullScan);
+    let includePerformance = Boolean(body.include_performance ?? false);
+    if (fullScan) includePerformance = true;
+    const result = await runFullUrlAnalysis({
+      url,
+      fullScan,
+      includePortScan,
+      includeMetadata,
+      includePerformance,
+      targetId,
+      persist: true,
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/web/src/app/api/system-stats/route.ts
+++ b/web/src/app/api/system-stats/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({
+    status: "success",
+    cpu_percent: 0,
+    memory_percent: 0,
+    disk_percent: 0,
+    network_sent: 0,
+    network_recv: 0,
+    uptime: 0,
+    load_avg: [0, 0, 0],
+    process_count: 0,
+  });
+}

--- a/web/src/app/api/targets/[id]/route.ts
+++ b/web/src/app/api/targets/[id]/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { requireSupabaseAuth } from "@/server/auth/policy";
+import {
+  deleteTargetForUser,
+  getTargetDetail,
+  requireUserSub,
+} from "@/server/db/monix-data";
+import { handleRouteError } from "@/server/transport/http";
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    const { id } = await ctx.params;
+    const data = await getTargetDetail(sub, id);
+    return NextResponse.json(data);
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    const { id } = await ctx.params;
+    await deleteTargetForUser(sub, id);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/web/src/app/api/targets/route.ts
+++ b/web/src/app/api/targets/route.ts
@@ -1,0 +1,43 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { requireSupabaseAuth } from "@/server/auth/policy";
+import { emailFromBearer } from "@/server/db/monix-auth-email";
+import {
+  createTargetForUser,
+  listTargetsPayload,
+  requireUserSub,
+} from "@/server/db/monix-data";
+import { handleRouteError } from "@/server/transport/http";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    const data = await listTargetsPayload(sub);
+    return NextResponse.json(data);
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { token } = await requireSupabaseAuth(request);
+    const sub = await requireUserSub(token);
+    const email = await emailFromBearer(token);
+    let body: Record<string, unknown> = {};
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid JSON body." },
+        { status: 400 },
+      );
+    }
+    const url = String(body.url ?? "").trim();
+    const environment = String(body.environment ?? "").trim();
+    const created = await createTargetForUser(sub, email, url, environment);
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    return handleRouteError(error);
+  }
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -12,92 +12,37 @@ import {
 } from "@/lib/feature-flags";
 import { supabase } from "@/lib/supabase";
 
-/** RFC1918-style hosts (not localhost / loopback). */
-function isLanHostname(hostname: string): boolean {
-  if (hostname === "localhost" || hostname === "127.0.0.1") return false;
-  return (
-    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname) ||
-    /^192\.168\.\d{1,3}\.\d{1,3}$/.test(hostname) ||
-    /^172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}$/.test(hostname)
-  );
-}
-
-/** In dev, API origin that matches this page (avoids LAN→127.0.0.1 fetch blocks). */
-function devDjangoOriginFromPage(): string {
-  if (typeof window === "undefined") return "http://127.0.0.1:8000";
-  const h = window.location.hostname;
-  if (h === "localhost" || h === "127.0.0.1") {
-    return `http://${h}:8000`;
-  }
-  if (isLanHostname(h)) {
-    return `http://${h}:8000`;
-  }
-  return "http://127.0.0.1:8000";
-}
-
-/** If page is on LAN but env points at loopback, rewrite so fetches are not blocked. */
-function devAlignEnvApiBaseWithPage(baseNoSlash: string): string {
-  if (typeof window === "undefined" || process.env.NODE_ENV !== "development") {
-    return baseNoSlash;
-  }
-  const page = window.location.hostname;
-  if (!isLanHostname(page)) {
-    return baseNoSlash;
-  }
-  try {
-    const u = new URL(baseNoSlash);
-    if (u.hostname === "localhost" || u.hostname === "127.0.0.1") {
-      u.hostname = page;
-      return u.origin;
-    }
-  } catch {
-    /* ignore */
-  }
-  return baseNoSlash;
-}
-
 /**
- * Base URL for Django API requests.
+ * Base URL for Monix API (Next.js Route Handlers under `/api/*`).
  *
- * **Browser (development):** Prefer `NEXT_PUBLIC_DJANGO_URL` if set. If you open the
- * app at a LAN URL (e.g. `http://10.x.x.x:3000`), the API base must use that same
- * host (e.g. `http://10.x.x.x:8000`) and Django must listen on `0.0.0.0:8000` —
- * otherwise the browser blocks `fetch` to `127.0.0.1` (Private Network Access).
- *
- * **Browser (production):** Use `NEXT_PUBLIC_DJANGO_URL` (your deployed API) or same-origin
- * `""` when the app and API share one host.
- *
- * **Server (SSR):** Absolute URL from env or `http://127.0.0.1:8000`.
+ * In the browser, requests use same-origin relative URLs (`""`).
+ * During SSR, use `NEXT_PUBLIC_SITE_URL` or infer from `VERCEL_URL`, else localhost.
  */
 export function djangoApiBase(): string {
   if (typeof window !== "undefined") {
-    const fromEnv = (
-      process.env.NEXT_PUBLIC_DJANGO_URL ||
-      process.env.NEXT_PUBLIC_API_URL ||
-      ""
-    ).trim();
-    if (fromEnv) {
-      return devAlignEnvApiBaseWithPage(fromEnv.replace(/\/$/, ""));
-    }
-    if (process.env.NODE_ENV === "development") {
-      return devDjangoOriginFromPage();
-    }
     return "";
   }
-  return (
-    process.env.NEXT_PUBLIC_DJANGO_URL ||
-    process.env.NEXT_PUBLIC_API_URL ||
-    "http://127.0.0.1:8000"
-  );
+  const site = (process.env.NEXT_PUBLIC_SITE_URL || "").trim();
+  if (site) return site.replace(/\/$/, "");
+  const vercel = process.env.VERCEL_URL?.trim();
+  if (vercel) return `https://${vercel}`.replace(/\/$/, "");
+  return "http://127.0.0.1:3000";
 }
 
-/** Shown in error messages — where Django should be listening (rewrite target). */
-function djangoApiDisplayUrl(): string {
-  return (
+/** Legacy Django base URL (dual-read verification only). */
+function djangoLegacyApiBase(): string {
+  const fromEnv = (
     process.env.NEXT_PUBLIC_DJANGO_URL ||
     process.env.NEXT_PUBLIC_API_URL ||
-    "http://127.0.0.1:8000"
-  );
+    ""
+  ).trim();
+  if (fromEnv) return fromEnv.replace(/\/$/, "");
+  return "http://127.0.0.1:8000";
+}
+
+/** Shown in error messages when the API cannot be reached. */
+function djangoApiDisplayUrl(): string {
+  return djangoApiBase() || djangoLegacyApiBase() || "this app origin";
 }
 
 function integrationApiBase(): string {
@@ -126,7 +71,9 @@ async function verifyDualReadStatus<T>({
     return;
   }
   try {
-    const baselineRes = await fetch(`${djangoApiBase()}${path}`, { headers });
+    const baselineRes = await fetch(`${djangoLegacyApiBase()}${path}`, {
+      headers,
+    });
     if (!baselineRes.ok) return;
     const baseline = (await baselineRes.json()) as T;
     if (isDifferent(baseline, nextPayload)) {
@@ -532,9 +479,8 @@ export async function analyzeUrl(
         error.message.includes("Failed to fetch")
       ) {
         throw new Error(
-          "Cannot connect to API server - ensure Django is running on " +
-            djangoApiDisplayUrl() +
-            " (e.g. cd core && python manage.py runserver)",
+          "Cannot connect to API server — ensure the Next.js app is reachable at " +
+            djangoApiDisplayUrl(),
         );
       }
     }
@@ -627,11 +573,12 @@ export async function getReport(
     `report:${reportId}`,
     async () => {
       const response = await fetch(
-        `${djangoApiBase()}/api/reports/${reportId}/`,
+        `${djangoApiBase()}/api/me/reports/${reportId}/`,
         {
           method: "GET",
           headers: {
             "Content-Type": "application/json",
+            ...(await authHeaders()),
           },
         },
       );

--- a/web/src/server/auth/gsc-oauth-state.ts
+++ b/web/src/server/auth/gsc-oauth-state.ts
@@ -1,0 +1,41 @@
+import { createHash, randomBytes } from "node:crypto";
+import { jwtVerify, SignJWT } from "jose";
+
+const SALT = "gsc-oauth-state-v1";
+
+function stateSecret(): Uint8Array {
+  const raw =
+    process.env.MONIX_GSC_STATE_SECRET?.trim() ||
+    process.env.GOOGLE_REFRESH_TOKEN_FERNET_KEY?.trim() ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY?.trim() ||
+    "";
+  if (!raw) {
+    throw new Error(
+      "Set MONIX_GSC_STATE_SECRET (or GOOGLE_REFRESH_TOKEN_FERNET_KEY / SUPABASE_SERVICE_ROLE_KEY) for GSC OAuth state signing.",
+    );
+  }
+  return new TextEncoder().encode(
+    createHash("sha256").update(`${SALT}:${raw}`, "utf8").digest("base64url"),
+  );
+}
+
+export async function signGscOAuthState(userSub: string): Promise<string> {
+  const secret = stateSecret();
+  return new SignJWT({ sub: userSub })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("15m")
+    .sign(secret);
+}
+
+export async function verifyGscOAuthState(state: string): Promise<string> {
+  const secret = stateSecret();
+  const { payload } = await jwtVerify(state, secret, { algorithms: ["HS256"] });
+  const sub = typeof payload.sub === "string" ? payload.sub : "";
+  if (!sub) throw new Error("invalid_state");
+  return sub;
+}
+
+export function randomNonce(): string {
+  return randomBytes(12).toString("base64url");
+}

--- a/web/src/server/bootstrap/integrations.ts
+++ b/web/src/server/bootstrap/integrations.ts
@@ -1,13 +1,11 @@
-import { DjangoApiClient } from "@/server/infrastructure/django-api-client";
-import { DjangoCloudflareRepository } from "@/server/repositories/django-cloudflare-repository";
-import { DjangoGscRepository } from "@/server/repositories/django-gsc-repository";
+import { SupabaseCloudflareRepository } from "@/server/repositories/supabase-cloudflare-repository";
+import { SupabaseGscRepository } from "@/server/repositories/supabase-gsc-repository";
 import { CloudflareService } from "@/server/services/cloudflare-service";
 import { GscService } from "@/server/services/gsc-service";
 
 export function buildIntegrationServices() {
-  const client = new DjangoApiClient();
   return {
-    gsc: new GscService(new DjangoGscRepository(client)),
-    cloudflare: new CloudflareService(new DjangoCloudflareRepository(client)),
+    gsc: new GscService(new SupabaseGscRepository()),
+    cloudflare: new CloudflareService(new SupabaseCloudflareRepository()),
   };
 }

--- a/web/src/server/crypto/fernet-tokens.ts
+++ b/web/src/server/crypto/fernet-tokens.ts
@@ -1,0 +1,44 @@
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Fernet = require("fernet") as {
+  Secret: new (secret64: string) => unknown;
+  Token: new (
+    opts: Record<string, unknown>,
+  ) => {
+    encode: (message?: string) => string;
+    decode: (token?: string) => string;
+  };
+};
+
+function fernetKeyMaterial(): string {
+  const explicit = process.env.GOOGLE_REFRESH_TOKEN_FERNET_KEY?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const fallback =
+    process.env.MONIX_FERNET_SECRET?.trim() ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY?.trim() ||
+    "";
+  if (!fallback) {
+    throw new Error(
+      "Set GOOGLE_REFRESH_TOKEN_FERNET_KEY (or MONIX_FERNET_SECRET / SUPABASE_SERVICE_ROLE_KEY) for token encryption.",
+    );
+  }
+  const digest = createHash("sha256").update(fallback, "utf8").digest();
+  return digest.toString("base64url");
+}
+
+export function encryptAtRest(plaintext: string): string {
+  const secret = new Fernet.Secret(fernetKeyMaterial());
+  const token = new Fernet.Token({ secret, ttl: 0 });
+  return token.encode(plaintext);
+}
+
+export function decryptAtRest(ciphertext: string): string {
+  const secret = new Fernet.Secret(fernetKeyMaterial());
+  const token = new Fernet.Token({ secret, ttl: 0, token: ciphertext });
+  return token.decode();
+}

--- a/web/src/server/db/monix-auth-email.ts
+++ b/web/src/server/db/monix-auth-email.ts
@@ -1,0 +1,13 @@
+import { verifySupabaseAccessToken } from "@/server/auth/supabase-jwt";
+
+export async function emailFromBearer(bearerJwt: string): Promise<string> {
+  const payload = await verifySupabaseAccessToken(bearerJwt);
+  const email =
+    (typeof payload.email === "string" && payload.email) ||
+    (typeof (payload as { user_metadata?: { email?: string } }).user_metadata
+      ?.email === "string" &&
+      (payload as { user_metadata?: { email?: string } }).user_metadata
+        ?.email) ||
+    "";
+  return email;
+}

--- a/web/src/server/db/monix-data.ts
+++ b/web/src/server/db/monix-data.ts
@@ -1,0 +1,467 @@
+import { verifySupabaseAccessToken } from "@/server/auth/supabase-jwt";
+import {
+  ensureMonixUser,
+  getMonixProfile,
+  updateMonixProfile,
+} from "@/server/db/monix-user";
+import { getSupabaseAdmin } from "@/server/db/supabase-admin";
+import { syncTargetSearchConsole } from "@/server/integrations/gsc-api";
+
+export async function requireUserSub(bearerJwt: string): Promise<string> {
+  const payload = await verifySupabaseAccessToken(bearerJwt);
+  const sub = typeof payload.sub === "string" ? payload.sub : "";
+  if (!sub) throw Object.assign(new Error("Unauthorized"), { status: 401 });
+  return sub;
+}
+
+function displayHost(url: string): string {
+  return url.replace(/^https?:\/\//, "").split("/")[0] ?? url;
+}
+
+function formatScanTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+async function scanCountByTarget(
+  db: ReturnType<typeof getSupabaseAdmin>,
+  targetIds: string[],
+): Promise<Map<string, number>> {
+  const m = new Map<string, number>();
+  for (const id of targetIds) m.set(id, 0);
+  if (!targetIds.length) return m;
+  const { data, error } = await db
+    .from("monix_scans")
+    .select("target_id")
+    .in("target_id", targetIds);
+  if (error || !data) return m;
+  for (const row of data as { target_id: string }[]) {
+    const tid = row.target_id;
+    m.set(tid, (m.get(tid) ?? 0) + 1);
+  }
+  return m;
+}
+
+export async function listTargetsPayload(userId: string): Promise<unknown[]> {
+  const db = getSupabaseAdmin();
+  const { data: targets, error } = await db
+    .from("monix_targets")
+    .select(
+      "id, url, environment, gsc_property_url, gsc_analytics, gsc_synced_at, gsc_sync_error, created_at",
+    )
+    .eq("owner_id", userId)
+    .order("created_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  const rows = (targets ?? []) as Record<string, unknown>[];
+  const ids = rows.map((t) => String(t.id));
+  const counts = await scanCountByTarget(db, ids);
+  const out: unknown[] = [];
+  for (const t of rows) {
+    const tid = String(t.id);
+    const { data: scans } = await db
+      .from("monix_scans")
+      .select("score, results, created_at")
+      .eq("target_id", tid)
+      .order("created_at", { ascending: false })
+      .limit(1);
+    const latest = scans?.[0] as Record<string, unknown> | undefined;
+    const results =
+      (latest?.results as Record<string, unknown> | undefined) ?? {};
+    const findings = (results.findings as unknown[]) ?? [];
+    const score = latest?.score != null ? Number(latest.score) : null;
+    out.push({
+      id: tid,
+      name: displayHost(String(t.url)),
+      url: t.url,
+      environment: t.environment ?? "",
+      ip: null,
+      location: null,
+      activity: latest ? `${findings.length} findings` : null,
+      status: latest
+        ? score != null && score > 80
+          ? "Healthy"
+          : "Warning"
+        : "Not scanned",
+      lastScan: latest?.created_at
+        ? formatScanTime(String(latest.created_at))
+        : null,
+      score,
+      created_at: t.created_at,
+      scan_count: counts.get(tid) ?? 0,
+      gsc_property_url: t.gsc_property_url || null,
+      gsc_analytics: t.gsc_analytics,
+      gsc_synced_at: t.gsc_synced_at ?? null,
+      gsc_sync_error: t.gsc_sync_error || null,
+    });
+  }
+  return out;
+}
+
+export async function getTargetDetail(
+  userId: string,
+  targetId: string,
+): Promise<Record<string, unknown>> {
+  const db = getSupabaseAdmin();
+  const { data: t, error } = await db
+    .from("monix_targets")
+    .select(
+      "id, url, environment, gsc_property_url, gsc_analytics, gsc_synced_at, gsc_sync_error, created_at",
+    )
+    .eq("id", targetId)
+    .eq("owner_id", userId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!t) throw Object.assign(new Error("Target not found."), { status: 404 });
+  const row = t as Record<string, unknown>;
+  const { data: scans } = await db
+    .from("monix_scans")
+    .select("report_id, score, created_at")
+    .eq("target_id", targetId)
+    .order("created_at", { ascending: false })
+    .limit(1);
+  const latest = scans?.[0] as Record<string, unknown> | undefined;
+  const score = latest?.score != null ? Number(latest.score) : null;
+  const cntMap = await scanCountByTarget(db, [targetId]);
+  return {
+    id: String(row.id),
+    name: displayHost(String(row.url)),
+    url: row.url,
+    environment: row.environment ?? "",
+    status: latest
+      ? score != null && score > 80
+        ? "Healthy"
+        : "Warning"
+      : "Not scanned",
+    lastScan: latest?.created_at
+      ? formatScanTime(String(latest.created_at))
+      : null,
+    score,
+    latest_report_id: latest?.report_id ? String(latest.report_id) : null,
+    created_at: row.created_at,
+    scan_count: cntMap.get(targetId) ?? 0,
+    gsc_property_url: row.gsc_property_url || null,
+    gsc_analytics: row.gsc_analytics,
+    gsc_synced_at: row.gsc_synced_at ?? null,
+    gsc_sync_error: row.gsc_sync_error || null,
+  };
+}
+
+export async function createTargetForUser(
+  userId: string,
+  email: string,
+  urlRaw: string,
+  environment: string,
+): Promise<Record<string, unknown>> {
+  let url = urlRaw.trim();
+  if (!url) throw Object.assign(new Error("url is required"), { status: 400 });
+  if (!url.startsWith("http://") && !url.startsWith("https://"))
+    url = `https://${url}`;
+  await ensureMonixUser(userId, email);
+  const db = getSupabaseAdmin();
+  const { data: created, error } = await db
+    .from("monix_targets")
+    .insert({ owner_id: userId, url, environment: environment.trim() })
+    .select(
+      "id, url, environment, gsc_property_url, gsc_analytics, gsc_synced_at, gsc_sync_error, created_at",
+    )
+    .single();
+  if (error) throw new Error(error.message);
+  const row = created as Record<string, unknown>;
+  try {
+    await syncTargetSearchConsole(userId, String(row.id), String(row.url));
+  } catch {
+    /* ignore */
+  }
+  const { data: refreshed } = await db
+    .from("monix_targets")
+    .select("gsc_property_url, gsc_analytics, gsc_synced_at, gsc_sync_error")
+    .eq("id", row.id)
+    .single();
+  const r = refreshed as Record<string, unknown> | null;
+  return {
+    id: String(row.id),
+    url: row.url,
+    name: displayHost(String(row.url)),
+    environment: row.environment,
+    gsc_property_url: r?.gsc_property_url || null,
+    gsc_analytics: r?.gsc_analytics ?? null,
+    gsc_synced_at: r?.gsc_synced_at ?? null,
+    gsc_sync_error: r?.gsc_sync_error || null,
+  };
+}
+
+export async function deleteTargetForUser(
+  userId: string,
+  targetId: string,
+): Promise<void> {
+  const db = getSupabaseAdmin();
+  const { error, count } = await db
+    .from("monix_targets")
+    .delete({ count: "exact" })
+    .eq("id", targetId)
+    .eq("owner_id", userId);
+  if (error) throw new Error(error.message);
+  if (!count)
+    throw Object.assign(new Error("Target not found."), { status: 404 });
+}
+
+function formatScanRow(
+  s: Record<string, unknown>,
+  idToUrl: Map<string, string>,
+): Record<string, unknown> {
+  const tid = s.target_id ? String(s.target_id) : null;
+  const url = String(s.url);
+  const targetName = tid
+    ? displayHost(idToUrl.get(tid) ?? url)
+    : displayHost(url);
+  return {
+    id: String(s.report_id),
+    report_id: String(s.report_id),
+    url,
+    score: Number(s.score),
+    created_at: s.created_at,
+    target_id: tid,
+    target_name: targetName,
+  };
+}
+
+export async function listScansForUser(userId: string): Promise<unknown[]> {
+  const db = getSupabaseAdmin();
+  const { data: targets } = await db
+    .from("monix_targets")
+    .select("id, url")
+    .eq("owner_id", userId);
+  const tlist = (targets ?? []) as { id: string; url: string }[];
+  if (!tlist.length) return [];
+  const targetIds = tlist.map((x) => x.id);
+  const idToUrl = new Map(tlist.map((t) => [t.id, t.url]));
+  const ownedUrls = tlist.map((t) => t.url);
+
+  const { data: byTarget } = await db
+    .from("monix_scans")
+    .select("report_id, url, score, created_at, target_id")
+    .in("target_id", targetIds)
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  const { data: orphans } = await db
+    .from("monix_scans")
+    .select("report_id, url, score, created_at, target_id")
+    .is("target_id", null)
+    .in("url", ownedUrls)
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  const merged = [...(byTarget ?? []), ...(orphans ?? [])] as Record<
+    string,
+    unknown
+  >[];
+  merged.sort(
+    (a, b) =>
+      new Date(String(b.created_at)).getTime() -
+      new Date(String(a.created_at)).getTime(),
+  );
+  const seen = new Set<string>();
+  const out: unknown[] = [];
+  for (const s of merged) {
+    const id = String(s.report_id);
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(formatScanRow(s, idToUrl));
+    if (out.length >= 100) break;
+  }
+  return out;
+}
+
+export async function scanLocationsForUser(userId: string): Promise<unknown[]> {
+  const db = getSupabaseAdmin();
+  const { data: targets } = await db
+    .from("monix_targets")
+    .select("id, url")
+    .eq("owner_id", userId);
+  const tlist = (targets ?? []) as { id: string; url: string }[];
+  if (!tlist.length) return [];
+  const targetIds = tlist.map((x) => x.id);
+  const ownedUrls = tlist.map((t) => t.url);
+
+  const a = await db
+    .from("monix_scans")
+    .select("report_id, url, score, results, target_id, created_at")
+    .in("target_id", targetIds)
+    .order("created_at", { ascending: false })
+    .limit(200);
+  const b = await db
+    .from("monix_scans")
+    .select("report_id, url, score, results, target_id, created_at")
+    .is("target_id", null)
+    .in("url", ownedUrls)
+    .order("created_at", { ascending: false })
+    .limit(200);
+  const rows = [...(a.data ?? []), ...(b.data ?? [])] as Record<
+    string,
+    unknown
+  >[];
+  rows.sort(
+    (x, y) =>
+      new Date(String(y.created_at)).getTime() -
+      new Date(String(x.created_at)).getTime(),
+  );
+
+  const out: unknown[] = [];
+  const seen = new Set<string>();
+  for (const s of rows.slice(0, 200)) {
+    const results = (s.results as Record<string, unknown> | undefined) ?? {};
+    const loc =
+      (results.server_location as Record<string, unknown> | undefined) ?? {};
+    const coords =
+      (loc.coordinates as Record<string, unknown> | undefined) ?? {};
+    const lat = coords.latitude;
+    const lng = coords.longitude;
+    if (lat == null || lng == null) continue;
+    const key = `${Number(lat).toFixed(2)},${Number(lng).toFixed(2)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({
+      url: String(s.url),
+      lat: Number(lat),
+      lng: Number(lng),
+      city: String(loc.city ?? ""),
+      country: String(loc.country ?? ""),
+      org: String(loc.org ?? ""),
+      score: Number(s.score),
+    });
+  }
+  return out;
+}
+
+export async function getReportEnvelopePublic(
+  reportId: string,
+): Promise<Record<string, unknown>> {
+  const db = getSupabaseAdmin();
+  const { data: scan, error } = await db
+    .from("monix_scans")
+    .select(
+      "report_id, url, score, results, created_at, expires_at, is_expired",
+    )
+    .eq("report_id", reportId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!scan)
+    throw Object.assign(new Error("Report not found."), { status: 404 });
+  const row = scan as {
+    is_expired: boolean;
+    expires_at: string;
+    report_id: string;
+    url: string;
+    score: number;
+    created_at: string;
+    results: unknown;
+  };
+  const expired =
+    row.is_expired || new Date(row.expires_at).getTime() <= Date.now();
+  if (expired)
+    throw Object.assign(new Error("Report not found."), { status: 404 });
+  return {
+    report_id: String(row.report_id),
+    url: row.url,
+    score: row.score,
+    created_at: row.created_at,
+    expires_at: row.expires_at,
+    results: row.results,
+  };
+}
+
+export async function getReportEnvelopeForUser(
+  reportId: string,
+  userId: string,
+): Promise<Record<string, unknown>> {
+  const db = getSupabaseAdmin();
+  const { data: scan, error } = await db
+    .from("monix_scans")
+    .select(
+      "report_id, url, score, results, created_at, expires_at, is_expired, target_id",
+    )
+    .eq("report_id", reportId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!scan)
+    throw Object.assign(new Error("Report not found."), { status: 404 });
+  const row = scan as {
+    is_expired: boolean;
+    expires_at: string;
+    target_id: string | null;
+    url: string;
+  };
+  const expired =
+    row.is_expired || new Date(row.expires_at).getTime() <= Date.now();
+  if (expired)
+    throw Object.assign(new Error("Report not found."), { status: 404 });
+
+  if (row.target_id) {
+    const { data: own } = await db
+      .from("monix_targets")
+      .select("id")
+      .eq("id", row.target_id)
+      .eq("owner_id", userId)
+      .maybeSingle();
+    if (!own) throw Object.assign(new Error("Forbidden"), { status: 403 });
+  } else {
+    const { data: targets } = await db
+      .from("monix_targets")
+      .select("url")
+      .eq("owner_id", userId);
+    const urls = new Set((targets ?? []).map((t: { url: string }) => t.url));
+    if (!urls.has(row.url))
+      throw Object.assign(new Error("Forbidden"), { status: 403 });
+  }
+  return getReportEnvelopePublic(reportId);
+}
+
+export async function buildMeResponse(
+  userId: string,
+  email: string,
+): Promise<Record<string, unknown>> {
+  await ensureMonixUser(userId, email);
+  const profile = await getMonixProfile(userId);
+  const first = profile?.first_name ?? "";
+  const last = profile?.last_name ?? "";
+  const display = `${first} ${last}`.trim() || email || userId;
+  const initials = (email || "U").slice(0, 2).toUpperCase();
+  return {
+    email: profile?.email ?? email,
+    name: display,
+    first_name: first,
+    last_name: last,
+    initials,
+  };
+}
+
+export async function patchProfileFromBody(
+  userId: string,
+  email: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  await ensureMonixUser(userId, email);
+  const patch: { first_name?: string; last_name?: string } = {};
+  if (typeof body.first_name === "string")
+    patch.first_name = body.first_name.trim();
+  if (typeof body.last_name === "string")
+    patch.last_name = body.last_name.trim();
+  if (Object.keys(patch).length) await updateMonixProfile(userId, patch);
+  const profile = await getMonixProfile(userId);
+  const first = profile?.first_name ?? "";
+  const last = profile?.last_name ?? "";
+  const display = `${first} ${last}`.trim() || profile?.email || email;
+  const initials = (profile?.email ?? email ?? "U").slice(0, 2).toUpperCase();
+  return { ok: true, name: display, initials };
+}
+
+export async function deleteUserData(userId: string): Promise<void> {
+  const db = getSupabaseAdmin();
+  await db.from("monix_users").delete().eq("id", userId);
+}

--- a/web/src/server/db/monix-user.ts
+++ b/web/src/server/db/monix-user.ts
@@ -1,0 +1,50 @@
+import { getSupabaseAdmin } from "@/server/db/supabase-admin";
+
+export async function ensureMonixUser(
+  userId: string,
+  email: string,
+): Promise<void> {
+  const db = getSupabaseAdmin();
+  const { error } = await db.from("monix_users").upsert(
+    {
+      id: userId,
+      email: email || null,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "id" },
+  );
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+export async function updateMonixProfile(
+  userId: string,
+  patch: { first_name?: string; last_name?: string },
+): Promise<void> {
+  const db = getSupabaseAdmin();
+  const row: Record<string, string> = { updated_at: new Date().toISOString() };
+  if (patch.first_name !== undefined) row.first_name = patch.first_name;
+  if (patch.last_name !== undefined) row.last_name = patch.last_name;
+  const { error } = await db.from("monix_users").update(row).eq("id", userId);
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+export async function getMonixProfile(userId: string): Promise<{
+  email: string | null;
+  first_name: string;
+  last_name: string;
+} | null> {
+  const db = getSupabaseAdmin();
+  const { data, error } = await db
+    .from("monix_users")
+    .select("email, first_name, last_name")
+    .eq("id", userId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(error.message);
+  }
+  return data;
+}

--- a/web/src/server/db/supabase-admin.ts
+++ b/web/src/server/db/supabase-admin.ts
@@ -1,0 +1,19 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let _admin: SupabaseClient | null = null;
+
+export function getSupabaseAdmin(): SupabaseClient {
+  const url =
+    process.env.SUPABASE_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+  if (!url || !key) {
+    throw new Error("Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.");
+  }
+  if (!_admin) {
+    _admin = createClient(url, key, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+  return _admin;
+}

--- a/web/src/server/domain/integrations.ts
+++ b/web/src/server/domain/integrations.ts
@@ -4,8 +4,10 @@ export interface GscAnalyticsRequest {
   end_date?: string;
 }
 
+export type GscConnectContext = { bearerToken: string; supabaseUserId: string };
+
 export interface GscRepository {
-  connectUrl(token: string): Promise<{ authorization_url: string }>;
+  connectUrl(ctx: GscConnectContext): Promise<{ authorization_url: string }>;
   callback(query: string): Promise<Response>;
   status(token: string): Promise<{ connected: boolean }>;
   sites(token: string): Promise<{ sites: unknown[] }>;

--- a/web/src/server/integrations/cloudflare-api.ts
+++ b/web/src/server/integrations/cloudflare-api.ts
@@ -1,0 +1,373 @@
+const CF_V4 = "https://api.cloudflare.com/client/v4";
+
+const ZONE_HTTP_ANALYTICS_QUERY = `
+query ZoneHttpAnalytics($zoneTag: string!, $start: Date!, $end: Date!) {
+  viewer {
+    zones(filter: {zoneTag: $zoneTag}) {
+      daily: httpRequests1dGroups(
+        limit: 400
+        orderBy: [date_ASC]
+        filter: { date_geq: $start, date_lt: $end }
+      ) {
+        dimensions { date }
+        sum {
+          requests
+          cachedRequests
+          bytes
+          pageViews
+          threats
+          countryMap { clientCountryName requests }
+          responseStatusMap { edgeResponseStatus requests }
+        }
+        uniq { uniques }
+      }
+    }
+  }
+}
+`;
+
+export class CloudflareApiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CloudflareApiError";
+  }
+}
+
+function headers(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token.trim()}`,
+    "Content-Type": "application/json",
+  };
+}
+
+async function cfRequest<T>(
+  method: string,
+  path: string,
+  token: string,
+  params?: URLSearchParams,
+): Promise<T> {
+  const url = `${CF_V4}${path}${params?.toString() ? `?${params}` : ""}`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: headers(token),
+      signal: AbortSignal.timeout(45_000),
+    });
+  } catch {
+    throw new CloudflareApiError("Could not reach Cloudflare.");
+  }
+  let data: { success?: boolean; errors?: { message?: string }[]; result?: T };
+  try {
+    data = (await res.json()) as typeof data;
+  } catch {
+    throw new CloudflareApiError("Invalid response from Cloudflare.");
+  }
+  if (!data.success) {
+    const msgs = (data.errors ?? [])
+      .map((e) => e.message ?? "")
+      .filter(Boolean);
+    throw new CloudflareApiError(
+      (msgs.join("; ") || "Cloudflare API error").slice(0, 500),
+    );
+  }
+  if (res.status >= 400) throw new CloudflareApiError(`HTTP ${res.status}`);
+  return data.result as T;
+}
+
+async function cfGraphql<T>(
+  token: string,
+  query: string,
+  variables: Record<string, string>,
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${CF_V4}/graphql`, {
+      method: "POST",
+      headers: headers(token),
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(60_000),
+    });
+  } catch {
+    throw new CloudflareApiError("Could not reach Cloudflare.");
+  }
+  let body: { data?: T; errors?: { message?: string }[] };
+  try {
+    body = (await res.json()) as typeof body;
+  } catch {
+    throw new CloudflareApiError("Invalid response from Cloudflare.");
+  }
+  if (body.errors?.length) {
+    const msg = body.errors.map((e) => e.message).join("; ");
+    throw new CloudflareApiError(msg.slice(0, 800) || "GraphQL error");
+  }
+  if (res.status >= 400) throw new CloudflareApiError(`HTTP ${res.status}`);
+  if (!body.data) throw new CloudflareApiError("Empty GraphQL data.");
+  return body.data;
+}
+
+export function verifyToken(token: string): Promise<void> {
+  return cfRequest("GET", "/user/tokens/verify", token).then((result) => {
+    if (result && typeof result === "object" && "status" in result) {
+      const st = String(
+        (result as { status?: string }).status ?? "",
+      ).toLowerCase();
+      if (st && st !== "active")
+        throw new CloudflareApiError("API token is not active.");
+    }
+  });
+}
+
+export async function listAccounts(
+  token: string,
+): Promise<Record<string, unknown>[]> {
+  const out: Record<string, unknown>[] = [];
+  let page = 1;
+  while (true) {
+    const batch = await cfRequest<Record<string, unknown>[]>(
+      "GET",
+      "/accounts",
+      token,
+      new URLSearchParams({ page: String(page), per_page: "50" }),
+    );
+    if (!Array.isArray(batch)) break;
+    out.push(...batch.filter((x) => x && typeof x === "object"));
+    if (batch.length < 50) break;
+    page += 1;
+  }
+  return out;
+}
+
+export async function listZonesAll(
+  token: string,
+): Promise<Record<string, unknown>[]> {
+  const out: Record<string, unknown>[] = [];
+  let page = 1;
+  while (true) {
+    const batch = await cfRequest<Record<string, unknown>[]>(
+      "GET",
+      "/zones",
+      token,
+      new URLSearchParams({ page: String(page), per_page: "50" }),
+    );
+    if (!Array.isArray(batch)) break;
+    out.push(...batch.filter((x) => x && typeof x === "object"));
+    if (batch.length < 50) break;
+    page += 1;
+  }
+  return out;
+}
+
+export async function summarizeForConnect(token: string): Promise<{
+  account_id: string;
+  account_name: string;
+  zones_count: number;
+}> {
+  await verifyToken(token);
+  const zones = await listZonesAll(token);
+  if (zones.length) {
+    const acc = (zones[0].account as Record<string, unknown> | undefined) ?? {};
+    const aid = String(acc.id ?? "");
+    let aname = String(acc.name ?? "").trim();
+    if (!aname) aname = "Cloudflare";
+    return { account_id: aid, account_name: aname, zones_count: zones.length };
+  }
+  let accounts: Record<string, unknown>[] = [];
+  try {
+    accounts = await listAccounts(token);
+  } catch {
+    accounts = [];
+  }
+  if (accounts.length) {
+    const a0 = accounts[0];
+    return {
+      account_id: String(a0.id ?? ""),
+      account_name: String(a0.name ?? "Cloudflare").trim() || "Cloudflare",
+      zones_count: 0,
+    };
+  }
+  return { account_id: "", account_name: "Cloudflare", zones_count: 0 };
+}
+
+export async function getZone(
+  token: string,
+  zoneId: string,
+): Promise<Record<string, unknown>> {
+  const result = await cfRequest<unknown>("GET", `/zones/${zoneId}`, token);
+  if (!result || typeof result !== "object")
+    throw new CloudflareApiError("Zone not found.");
+  return result as Record<string, unknown>;
+}
+
+export function zonesToApiRows(zones: Record<string, unknown>[]): Array<{
+  id: string;
+  name: string;
+  status: string;
+  plan_name: string;
+}> {
+  const rows: Array<{
+    id: string;
+    name: string;
+    status: string;
+    plan_name: string;
+  }> = [];
+  for (const z of zones) {
+    const plan =
+      z.plan && typeof z.plan === "object"
+        ? (z.plan as Record<string, unknown>)
+        : {};
+    const planName = String(plan.name ?? plan.legacy_id ?? "");
+    rows.push({
+      id: String(z.id ?? ""),
+      name: String(z.name ?? ""),
+      status: String(z.status ?? ""),
+      plan_name: planName,
+    });
+  }
+  return rows.filter((r) => r.id);
+}
+
+function mergeCountries(
+  maps: Record<string, unknown>[][],
+): { country: string; requests: number }[] {
+  const by: Record<string, number> = {};
+  for (const cmap of maps) {
+    for (const c of cmap) {
+      const cc = String(c.clientCountryName ?? "");
+      by[cc] = (by[cc] ?? 0) + Number(c.requests ?? 0);
+    }
+  }
+  return Object.entries(by)
+    .filter(([k]) => k)
+    .map(([country, requests]) => ({ country, requests }))
+    .sort((a, b) => b.requests - a.requests);
+}
+
+function mergeStatus(
+  maps: Record<string, unknown>[][],
+): { status: string; requests: number }[] {
+  const by: Record<string, number> = {};
+  for (const smap of maps) {
+    for (const s of smap) {
+      const code = s.edgeResponseStatus;
+      const key = code != null ? String(code) : "";
+      by[key] = (by[key] ?? 0) + Number(s.requests ?? 0);
+    }
+  }
+  return Object.entries(by)
+    .filter(([k]) => k)
+    .map(([status, requests]) => ({ status, requests }))
+    .sort((a, b) => b.requests - a.requests);
+}
+
+export function parseGraphqlZoneAnalytics(
+  data: Record<string, unknown>,
+  zoneId: string,
+  zoneName: string,
+  periodDays: number,
+): Record<string, unknown> {
+  const viewer = (data.viewer as Record<string, unknown>) ?? {};
+  const zones = viewer.zones as unknown[] | undefined;
+  if (!zones?.[0] || typeof zones[0] !== "object") {
+    throw new CloudflareApiError("Zone not found or no analytics access.");
+  }
+  const z = zones[0] as Record<string, unknown>;
+  let daily = z.daily as unknown[] | undefined;
+  if (!Array.isArray(daily)) daily = [];
+
+  const series: Record<string, unknown>[] = [];
+  const countryMaps: Record<string, unknown>[][] = [];
+  const statusMaps: Record<string, unknown>[][] = [];
+
+  for (const row of daily) {
+    if (!row || typeof row !== "object") continue;
+    const r = row as Record<string, unknown>;
+    const dims = (r.dimensions as Record<string, unknown>) ?? {};
+    const dt = String(dims.date ?? "").slice(0, 10);
+    if (!dt) continue;
+    const s = (r.sum as Record<string, unknown>) ?? {};
+    const u = (r.uniq as Record<string, unknown>) ?? {};
+    series.push({
+      date: dt,
+      requests: Number(s.requests ?? 0),
+      cached_requests: Number(s.cachedRequests ?? 0),
+      threats: Number(s.threats ?? 0),
+      bandwidth: Number(s.bytes ?? 0),
+      pageviews: Number(s.pageViews ?? 0),
+      uniques: Number(u.uniques ?? 0),
+    });
+    const cm = s.countryMap as unknown[] | undefined;
+    const sm = s.responseStatusMap as unknown[] | undefined;
+    if (Array.isArray(cm) && cm.length) {
+      countryMaps.push(
+        cm.filter(
+          (x): x is Record<string, unknown> =>
+            Boolean(x) && typeof x === "object",
+        ),
+      );
+    }
+    if (Array.isArray(sm) && sm.length) {
+      statusMaps.push(
+        sm.filter(
+          (x): x is Record<string, unknown> =>
+            Boolean(x) && typeof x === "object",
+        ),
+      );
+    }
+  }
+
+  const totals = {
+    requests: series.reduce((a, x) => a + Number(x.requests), 0),
+    cached_requests: series.reduce((a, x) => a + Number(x.cached_requests), 0),
+    bandwidth_bytes: series.reduce((a, x) => a + Number(x.bandwidth), 0),
+    threats: series.reduce((a, x) => a + Number(x.threats), 0),
+    pageviews: series.reduce((a, x) => a + Number(x.pageviews), 0),
+    uniques: series.reduce((a, x) => a + Number(x.uniques), 0),
+  };
+
+  const top_countries = countryMaps.length
+    ? mergeCountries(countryMaps).slice(0, 32)
+    : [];
+  const status_codes = statusMaps.length
+    ? mergeStatus(statusMaps).slice(0, 32)
+    : [];
+
+  return {
+    zone_id: zoneId,
+    zone_name: zoneName,
+    period_days: periodDays,
+    totals,
+    series,
+    top_countries,
+    status_codes,
+  };
+}
+
+export async function fetchZoneAnalyticsDashboard(
+  token: string,
+  zoneId: string,
+  zoneName: string,
+  days: number,
+): Promise<Record<string, unknown>> {
+  let d = days;
+  if (d < 1) d = 1;
+  if (d > 366) d = 366;
+  const now = new Date();
+  const endUtc = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const startUtc = new Date(endUtc);
+  startUtc.setUTCDate(startUtc.getUTCDate() - d);
+  const startD = startUtc.toISOString().slice(0, 10);
+  const endExclusive = new Date(endUtc);
+  endExclusive.setUTCDate(endExclusive.getUTCDate() + 1);
+  const endExclusiveStr = endExclusive.toISOString().slice(0, 10);
+
+  const variables = { zoneTag: zoneId, start: startD, end: endExclusiveStr };
+  const data = await cfGraphql<Record<string, unknown>>(
+    token,
+    ZONE_HTTP_ANALYTICS_QUERY,
+    variables,
+  );
+  return parseGraphqlZoneAnalytics(data, zoneId, zoneName, d);
+}

--- a/web/src/server/integrations/gsc-api.ts
+++ b/web/src/server/integrations/gsc-api.ts
@@ -1,0 +1,417 @@
+import { decryptAtRest, encryptAtRest } from "@/server/crypto/fernet-tokens";
+import { getSupabaseAdmin } from "@/server/db/supabase-admin";
+
+const GOOGLE_AUTH = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN = "https://oauth2.googleapis.com/token";
+const GSC_SITES = "https://www.googleapis.com/webmasters/v3/sites";
+const WEBMASTERS_READONLY =
+  "https://www.googleapis.com/auth/webmasters.readonly";
+const SCOPES = ["openid", "email", "profile", WEBMASTERS_READONLY].join(" ");
+
+export function googleOAuthConfig(): {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+} {
+  const clientId = process.env.GOOGLE_CLIENT_ID?.trim() || "";
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim() || "";
+  const redirectUri =
+    process.env.GOOGLE_REDIRECT_URI?.trim() ||
+    process.env.GOOGLE_REDIRECT_URL?.trim() ||
+    "";
+  return { clientId, clientSecret, redirectUri };
+}
+
+export function buildGscAuthorizationUrl(state: string): string {
+  const { clientId, redirectUri } = googleOAuthConfig();
+  if (!clientId || !redirectUri) {
+    throw new Error(
+      "Set GOOGLE_CLIENT_ID and GOOGLE_REDIRECT_URI for Search Console OAuth.",
+    );
+  }
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: SCOPES,
+    state,
+    access_type: "offline",
+    prompt: "consent",
+    include_granted_scopes: "true",
+  });
+  return `${GOOGLE_AUTH}?${params.toString()}`;
+}
+
+export async function exchangeCodeForTokens(code: string): Promise<{
+  access_token: string;
+  refresh_token?: string | null;
+  expires_in?: number | null;
+}> {
+  const { clientId, clientSecret, redirectUri } = googleOAuthConfig();
+  if (!clientSecret) throw new Error("GOOGLE_CLIENT_SECRET must be set.");
+  const body = new URLSearchParams({
+    code,
+    client_id: clientId,
+    client_secret: clientSecret,
+    redirect_uri: redirectUri,
+    grant_type: "authorization_code",
+  });
+  const res = await fetch(GOOGLE_TOKEN, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!res.ok) throw new Error(`Token exchange failed: ${res.status}`);
+  const data = (await res.json()) as Record<string, unknown>;
+  return {
+    access_token: String(data.access_token),
+    refresh_token: (data.refresh_token as string) ?? null,
+    expires_in: (data.expires_in as number) ?? null,
+  };
+}
+
+export async function refreshAccessToken(refreshPlain: string): Promise<{
+  access_token: string;
+  expires_in?: number | null;
+}> {
+  const { clientId, clientSecret } = googleOAuthConfig();
+  const body = new URLSearchParams({
+    refresh_token: refreshPlain,
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: "refresh_token",
+  });
+  const res = await fetch(GOOGLE_TOKEN, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!res.ok) throw new Error(`Token refresh failed: ${res.status}`);
+  const data = (await res.json()) as Record<string, unknown>;
+  return {
+    access_token: String(data.access_token),
+    expires_in: (data.expires_in as number) ?? null,
+  };
+}
+
+export async function listSites(
+  accessToken: string,
+): Promise<Record<string, unknown>[]> {
+  const res = await fetch(GSC_SITES, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) throw new Error(`GSC list sites failed: ${res.status}`);
+  const payload = (await res.json()) as {
+    siteEntry?: Record<string, unknown>[];
+  };
+  return payload.siteEntry ?? [];
+}
+
+function normalizeHost(host: string | null | undefined): string | null {
+  if (!host) return null;
+  const h = host.toLowerCase();
+  return h.startsWith("www.") ? h.slice(4) : h;
+}
+
+export function gscPropertyMatchesTarget(
+  siteUrl: string,
+  targetUrl: string,
+): boolean {
+  const t = new URL(
+    targetUrl.startsWith("http") ? targetUrl : `https://${targetUrl}`,
+  );
+  const th = normalizeHost(t.hostname);
+  if (!th) return false;
+  const su = siteUrl.trim();
+  if (su.startsWith("sc-domain:")) {
+    const dom =
+      su.split(":", 2)[1]?.trim().toLowerCase().replace(/\/$/, "") ?? "";
+    if (th === dom) return true;
+    if (th.endsWith(`.${dom}`)) return true;
+    return false;
+  }
+  const p = new URL(su.includes("://") ? su : `https://${su}`);
+  const sh = normalizeHost(p.hostname);
+  return Boolean(sh && th === sh);
+}
+
+export function pickMatchingSiteUrl(
+  sites: Record<string, unknown>[],
+  targetUrl: string,
+): string | null {
+  for (const entry of sites) {
+    const sUrl = String(entry.siteUrl ?? "").trim();
+    if (sUrl && gscPropertyMatchesTarget(sUrl, targetUrl)) return sUrl;
+  }
+  return null;
+}
+
+function defaultDateRange(): { start: string; end: string } {
+  const end = new Date();
+  const start = new Date(end);
+  start.setDate(start.getDate() - 28);
+  return {
+    start: start.toISOString().slice(0, 10),
+    end: end.toISOString().slice(0, 10),
+  };
+}
+
+async function searchAnalyticsQuery(
+  siteUrl: string,
+  accessToken: string,
+  start: string,
+  end: string,
+  dimensions: string[] | null,
+  rowLimit?: number,
+): Promise<Record<string, unknown>> {
+  const encoded = encodeURIComponent(siteUrl);
+  const url = `https://www.googleapis.com/webmasters/v3/sites/${encoded}/searchAnalytics/query`;
+  const body: Record<string, unknown> = {
+    startDate: start,
+    endDate: end,
+    dataState: "all",
+  };
+  if (dimensions) {
+    body.dimensions = dimensions;
+    body.rowLimit = rowLimit ?? 25;
+  }
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`searchAnalytics ${res.status}`);
+  return (await res.json()) as Record<string, unknown>;
+}
+
+function summarizeRows(
+  rows: Record<string, unknown>[] | undefined,
+): Record<string, number | null> {
+  const r = rows ?? [];
+  if (!r.length)
+    return { clicks: null, impressions: null, ctr: null, position: null };
+  let clicks = 0;
+  let impr = 0;
+  let posW = 0;
+  for (const row of r) {
+    clicks += Number(row.clicks ?? 0);
+    impr += Number(row.impressions ?? 0);
+    posW += Number(row.position ?? 0) * Number(row.impressions ?? 0);
+  }
+  return {
+    clicks,
+    impressions: impr,
+    ctr: impr ? clicks / impr : null,
+    position: impr ? posW / impr : null,
+  };
+}
+
+export async function fetchGscBundleForSite(
+  siteUrl: string,
+  accessToken: string,
+  start?: string,
+  end?: string,
+): Promise<Record<string, unknown>> {
+  const dr = defaultDateRange();
+  const startD = start ?? dr.start;
+  const endD = end ?? dr.end;
+  const totalPayload = await searchAnalyticsQuery(
+    siteUrl,
+    accessToken,
+    startD,
+    endD,
+    null,
+  );
+  const summary = summarizeRows(
+    totalPayload.rows as Record<string, unknown>[] | undefined,
+  );
+  const queriesPayload = await searchAnalyticsQuery(
+    siteUrl,
+    accessToken,
+    startD,
+    endD,
+    ["query"],
+    50,
+  );
+  const qRows = (queriesPayload.rows as Record<string, unknown>[]) ?? [];
+  const top_queries = qRows.map((row) => {
+    const keys = (row.keys as string[]) ?? [];
+    return {
+      query: keys[0] ?? "",
+      clicks: Number(row.clicks ?? 0),
+      impressions: Number(row.impressions ?? 0),
+      ctr: Number(row.ctr ?? 0),
+      position: Number(row.position ?? 0),
+    };
+  });
+  return {
+    summary,
+    top_queries,
+    start_date: startD,
+    end_date: endD,
+  };
+}
+
+export async function getValidGscAccessToken(
+  userId: string,
+): Promise<string | null> {
+  const db = getSupabaseAdmin();
+  const { data, error } = await db
+    .from("monix_gsc_credentials")
+    .select("refresh_token_encrypted, access_token, access_token_expires_at")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error || !data) return null;
+  const row = data as {
+    refresh_token_encrypted: string;
+    access_token: string;
+    access_token_expires_at: string | null;
+  };
+  const skewMs = 120_000;
+  const now = Date.now();
+  if (
+    row.access_token &&
+    row.access_token_expires_at &&
+    new Date(row.access_token_expires_at).getTime() > now + skewMs
+  ) {
+    return row.access_token;
+  }
+  let refreshPlain: string;
+  try {
+    refreshPlain = decryptAtRest(row.refresh_token_encrypted);
+  } catch {
+    return null;
+  }
+  try {
+    const bundle = await refreshAccessToken(refreshPlain);
+    const expiresAt =
+      bundle.expires_in != null
+        ? new Date(now + bundle.expires_in * 1000).toISOString()
+        : null;
+    await db
+      .from("monix_gsc_credentials")
+      .update({
+        access_token: bundle.access_token,
+        access_token_expires_at: expiresAt,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("user_id", userId);
+    return bundle.access_token;
+  } catch {
+    return null;
+  }
+}
+
+export async function syncTargetSearchConsole(
+  userId: string,
+  targetId: string,
+  targetUrl: string,
+): Promise<void> {
+  const db = getSupabaseAdmin();
+  const token = await getValidGscAccessToken(userId);
+  const now = new Date().toISOString();
+  if (!token) {
+    await db
+      .from("monix_targets")
+      .update({
+        gsc_property_url: "",
+        gsc_analytics: null,
+        gsc_synced_at: now,
+        gsc_sync_error: "",
+      })
+      .eq("id", targetId);
+    return;
+  }
+  let sites: Record<string, unknown>[];
+  try {
+    sites = await listSites(token);
+  } catch {
+    await db
+      .from("monix_targets")
+      .update({
+        gsc_synced_at: now,
+        gsc_sync_error: "Could not list Search Console properties.",
+      })
+      .eq("id", targetId);
+    return;
+  }
+  const match = pickMatchingSiteUrl(sites, targetUrl);
+  if (!match) {
+    await db
+      .from("monix_targets")
+      .update({
+        gsc_property_url: "",
+        gsc_analytics: null,
+        gsc_synced_at: now,
+        gsc_sync_error:
+          "No verified Search Console property matches this URL's domain.",
+      })
+      .eq("id", targetId);
+    return;
+  }
+  try {
+    const bundle = await fetchGscBundleForSite(match, token);
+    await db
+      .from("monix_targets")
+      .update({
+        gsc_property_url: match,
+        gsc_analytics: bundle,
+        gsc_synced_at: now,
+        gsc_sync_error: "",
+      })
+      .eq("id", targetId);
+  } catch {
+    await db
+      .from("monix_targets")
+      .update({
+        gsc_property_url: match,
+        gsc_analytics: null,
+        gsc_synced_at: now,
+        gsc_sync_error: "Could not fetch Search Analytics for this property.",
+      })
+      .eq("id", targetId);
+  }
+}
+
+export async function saveGscTokensFromOAuth(
+  userId: string,
+  accessToken: string,
+  refreshToken: string | null | undefined,
+  expiresIn: number | null | undefined,
+): Promise<void> {
+  const db = getSupabaseAdmin();
+  const now = Date.now();
+  const expiresAt =
+    expiresIn != null ? new Date(now + expiresIn * 1000).toISOString() : null;
+
+  let refreshEnc: string;
+  if (refreshToken) {
+    refreshEnc = encryptAtRest(refreshToken);
+  } else {
+    const { data: existing } = await db
+      .from("monix_gsc_credentials")
+      .select("refresh_token_encrypted")
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (!existing?.refresh_token_encrypted) {
+      throw new Error(
+        "Google did not return a refresh token. Revoke app access in Google Account settings and connect again.",
+      );
+    }
+    refreshEnc = existing.refresh_token_encrypted as string;
+  }
+
+  await db.from("monix_gsc_credentials").upsert(
+    {
+      user_id: userId,
+      refresh_token_encrypted: refreshEnc,
+      access_token: accessToken,
+      access_token_expires_at: expiresAt,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "user_id" },
+  );
+}

--- a/web/src/server/repositories/django-gsc-repository.ts
+++ b/web/src/server/repositories/django-gsc-repository.ts
@@ -7,11 +7,12 @@ import type { DjangoApiClient } from "@/server/infrastructure/django-api-client"
 export class DjangoGscRepository implements GscRepository {
   constructor(private readonly client: DjangoApiClient) {}
 
-  connectUrl(token: string) {
+  connectUrl(ctx: { bearerToken: string; supabaseUserId: string }) {
+    void ctx.supabaseUserId;
     return this.client.requestJson<{ authorization_url: string }>(
       "/api/gsc/connect/",
       { method: "GET" },
-      token,
+      ctx.bearerToken,
     );
   }
 

--- a/web/src/server/repositories/supabase-cloudflare-repository.ts
+++ b/web/src/server/repositories/supabase-cloudflare-repository.ts
@@ -1,0 +1,170 @@
+import { verifySupabaseAccessToken } from "@/server/auth/supabase-jwt";
+import { decryptAtRest, encryptAtRest } from "@/server/crypto/fernet-tokens";
+import { getSupabaseAdmin } from "@/server/db/supabase-admin";
+import type { CloudflareRepository } from "@/server/domain/integrations";
+import {
+  CloudflareApiError,
+  fetchZoneAnalyticsDashboard,
+  getZone,
+  listZonesAll,
+  summarizeForConnect,
+  zonesToApiRows,
+} from "@/server/integrations/cloudflare-api";
+
+async function requireSub(bearerJwt: string): Promise<string> {
+  const payload = await verifySupabaseAccessToken(bearerJwt);
+  const sub = typeof payload.sub === "string" ? payload.sub : "";
+  if (!sub) throw new Error("Unauthorized");
+  return sub;
+}
+
+async function decryptStoredToken(userId: string): Promise<string | null> {
+  const { data } = await getSupabaseAdmin()
+    .from("monix_cloudflare_credentials")
+    .select("api_token_encrypted")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (!data?.api_token_encrypted) return null;
+  try {
+    return decryptAtRest(data.api_token_encrypted as string);
+  } catch {
+    return null;
+  }
+}
+
+export class SupabaseCloudflareRepository implements CloudflareRepository {
+  async status(bearerJwt: string): Promise<{
+    connected: boolean;
+    account_name?: string;
+    account_id?: string;
+    zones_count?: number;
+  }> {
+    const sub = await requireSub(bearerJwt);
+    const { data } = await getSupabaseAdmin()
+      .from("monix_cloudflare_credentials")
+      .select("account_name, account_id, zones_count")
+      .eq("user_id", sub)
+      .maybeSingle();
+    if (!data) return { connected: false };
+    return {
+      connected: true,
+      account_name: (data.account_name as string) || "Cloudflare",
+      account_id: (data.account_id as string) || undefined,
+      zones_count: Number(data.zones_count ?? 0),
+    };
+  }
+
+  async connect(
+    bearerJwt: string,
+    payload: { api_token: string },
+  ): Promise<{ success: boolean; account_name: string; zones_count: number }> {
+    const sub = await requireSub(bearerJwt);
+    const token = (payload.api_token ?? "").trim();
+    if (!token) {
+      throw Object.assign(new Error("api_token is required."), { status: 400 });
+    }
+    let summary: {
+      account_id: string;
+      account_name: string;
+      zones_count: number;
+    };
+    try {
+      summary = await summarizeForConnect(token);
+    } catch (e) {
+      if (e instanceof CloudflareApiError) {
+        throw Object.assign(new Error(e.message), { status: 400 });
+      }
+      throw Object.assign(new Error("Could not verify Cloudflare token."), {
+        status: 502,
+      });
+    }
+    const enc = encryptAtRest(token);
+    await getSupabaseAdmin()
+      .from("monix_cloudflare_credentials")
+      .upsert(
+        {
+          user_id: sub,
+          api_token_encrypted: enc,
+          account_id: summary.account_id.slice(0, 64),
+          account_name: summary.account_name.slice(0, 255),
+          zones_count: summary.zones_count,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id" },
+      );
+    return {
+      success: true,
+      account_name: summary.account_name,
+      zones_count: summary.zones_count,
+    };
+  }
+
+  async disconnect(bearerJwt: string): Promise<{ ok: boolean }> {
+    const sub = await requireSub(bearerJwt);
+    await getSupabaseAdmin()
+      .from("monix_cloudflare_credentials")
+      .delete()
+      .eq("user_id", sub);
+    return { ok: true };
+  }
+
+  async zones(
+    bearerJwt: string,
+  ): Promise<
+    Array<{ id: string; name: string; status: string; plan_name: string }>
+  > {
+    const sub = await requireSub(bearerJwt);
+    const plain = await decryptStoredToken(sub);
+    if (!plain) {
+      throw Object.assign(new Error("Cloudflare is not connected."), {
+        status: 400,
+      });
+    }
+    try {
+      const zones = await listZonesAll(plain);
+      const rows = zonesToApiRows(zones);
+      await getSupabaseAdmin()
+        .from("monix_cloudflare_credentials")
+        .update({
+          zones_count: rows.length,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("user_id", sub);
+      return rows;
+    } catch (e) {
+      if (e instanceof CloudflareApiError) {
+        throw Object.assign(new Error(e.message), { status: 502 });
+      }
+      throw e;
+    }
+  }
+
+  async analytics(
+    bearerJwt: string,
+    zoneId: string,
+    days: number,
+  ): Promise<unknown> {
+    const sub = await requireSub(bearerJwt);
+    const zid = zoneId.trim();
+    if (!zid) {
+      throw Object.assign(new Error("zone_id is required."), { status: 400 });
+    }
+    const plain = await decryptStoredToken(sub);
+    if (!plain) {
+      throw Object.assign(new Error("Cloudflare is not connected."), {
+        status: 400,
+      });
+    }
+    try {
+      const z = await getZone(plain, zid);
+      const zoneName = String(z.name ?? "");
+      return await fetchZoneAnalyticsDashboard(plain, zid, zoneName, days);
+    } catch (e) {
+      if (e instanceof CloudflareApiError) {
+        const status = e.message.includes("not found") ? 400 : 502;
+        throw Object.assign(new Error(e.message), { status });
+      }
+      throw e;
+    }
+  }
+}

--- a/web/src/server/repositories/supabase-gsc-repository.ts
+++ b/web/src/server/repositories/supabase-gsc-repository.ts
@@ -1,0 +1,224 @@
+import { NextResponse } from "next/server";
+import {
+  signGscOAuthState,
+  verifyGscOAuthState,
+} from "@/server/auth/gsc-oauth-state";
+import { verifySupabaseAccessToken } from "@/server/auth/supabase-jwt";
+import { ensureMonixUser } from "@/server/db/monix-user";
+import { getSupabaseAdmin } from "@/server/db/supabase-admin";
+import type {
+  GscAnalyticsRequest,
+  GscConnectContext,
+  GscRepository,
+} from "@/server/domain/integrations";
+import {
+  buildGscAuthorizationUrl,
+  exchangeCodeForTokens,
+  fetchGscBundleForSite,
+  getValidGscAccessToken,
+  listSites,
+  saveGscTokensFromOAuth,
+  syncTargetSearchConsole,
+} from "@/server/integrations/gsc-api";
+
+function gscSuccessRedirect(): string {
+  const explicit = process.env.GSC_OAUTH_SUCCESS_URL?.trim();
+  if (explicit) return explicit;
+  const base = (
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    process.env.FRONTEND_URL?.trim() ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "") ||
+    "http://localhost:3000"
+  ).replace(/\/$/, "");
+  return `${base}/dashboard/projects?gsc=connected`;
+}
+
+function gscErrorRedirect(): string {
+  if (process.env.GSC_OAUTH_ERROR_URL?.trim())
+    return process.env.GSC_OAUTH_ERROR_URL.trim();
+  const base = (
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    process.env.FRONTEND_URL?.trim() ||
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "") ||
+    "http://localhost:3000"
+  ).replace(/\/$/, "");
+  return `${base}/dashboard/projects?gsc=error`;
+}
+
+async function requireSubFromBearer(bearerJwt: string): Promise<string> {
+  const payload = await verifySupabaseAccessToken(bearerJwt);
+  const sub = typeof payload.sub === "string" ? payload.sub : "";
+  if (!sub) throw new Error("Unauthorized");
+  return sub;
+}
+
+export class SupabaseGscRepository implements GscRepository {
+  async connectUrl(
+    ctx: GscConnectContext,
+  ): Promise<{ authorization_url: string }> {
+    const state = await signGscOAuthState(ctx.supabaseUserId);
+    const authorization_url = buildGscAuthorizationUrl(state);
+    return { authorization_url };
+  }
+
+  async callback(query: string): Promise<Response> {
+    const errBase = gscErrorRedirect();
+    const okUrl = gscSuccessRedirect();
+    const appendReason = (base: string, reason: string) =>
+      `${base}${base.includes("?") ? "&" : "?"}reason=${encodeURIComponent(reason)}`;
+
+    const params = new URLSearchParams(query);
+    const err = params.get("error");
+    if (err) {
+      return NextResponse.redirect(appendReason(errBase, err));
+    }
+    const code = params.get("code");
+    const state = params.get("state");
+    if (!code || !state) {
+      return NextResponse.redirect(appendReason(errBase, "invalid_callback"));
+    }
+    let userId: string;
+    try {
+      userId = await verifyGscOAuthState(state);
+    } catch {
+      return NextResponse.redirect(appendReason(errBase, "invalid_callback"));
+    }
+    try {
+      const bundle = await exchangeCodeForTokens(code);
+      let email = "";
+      try {
+        const { data, error } =
+          await getSupabaseAdmin().auth.admin.getUserById(userId);
+        if (!error && data.user?.email) email = data.user.email;
+      } catch {
+        /* optional */
+      }
+      await ensureMonixUser(userId, email);
+      await saveGscTokensFromOAuth(
+        userId,
+        bundle.access_token,
+        bundle.refresh_token,
+        bundle.expires_in ?? null,
+      );
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "";
+      if (msg.includes("refresh token")) {
+        return NextResponse.redirect(appendReason(errBase, "no_refresh_token"));
+      }
+      return NextResponse.redirect(appendReason(errBase, "token_exchange"));
+    }
+    return NextResponse.redirect(okUrl);
+  }
+
+  async status(bearerJwt: string): Promise<{ connected: boolean }> {
+    const sub = await requireSubFromBearer(bearerJwt);
+    const { data } = await getSupabaseAdmin()
+      .from("monix_gsc_credentials")
+      .select("user_id")
+      .eq("user_id", sub)
+      .maybeSingle();
+    return { connected: Boolean(data) };
+  }
+
+  async sites(bearerJwt: string): Promise<{ sites: unknown[] }> {
+    const sub = await requireSubFromBearer(bearerJwt);
+    const access = await getValidGscAccessToken(sub);
+    if (!access) {
+      throw Object.assign(
+        new Error("Google Search Console is not connected."),
+        { status: 400 },
+      );
+    }
+    const sites = await listSites(access);
+    return { sites };
+  }
+
+  async analytics(
+    bearerJwt: string,
+    body: GscAnalyticsRequest,
+  ): Promise<unknown> {
+    const sub = await requireSubFromBearer(bearerJwt);
+    const siteUrl = (body.site_url ?? "").trim();
+    if (!siteUrl) {
+      throw Object.assign(new Error("site_url is required."), { status: 400 });
+    }
+    const access = await getValidGscAccessToken(sub);
+    if (!access) {
+      throw Object.assign(
+        new Error("Google Search Console is not connected."),
+        { status: 400 },
+      );
+    }
+    let start: string | undefined;
+    let end: string | undefined;
+    if (body.start_date) {
+      const s = String(body.start_date).trim();
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) {
+        throw Object.assign(new Error("Invalid start_date."), { status: 400 });
+      }
+      start = s;
+    }
+    if (body.end_date) {
+      const e = String(body.end_date).trim();
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(e)) {
+        throw Object.assign(new Error("Invalid end_date."), { status: 400 });
+      }
+      end = e;
+    }
+    const siteList = await listSites(access);
+    const allowed = new Set(
+      siteList.map((s) => String((s as { siteUrl?: string }).siteUrl ?? "")),
+    );
+    if (!allowed.has(siteUrl)) {
+      throw Object.assign(
+        new Error(
+          "site_url is not in your verified Search Console properties.",
+        ),
+        { status: 403 },
+      );
+    }
+    return fetchGscBundleForSite(siteUrl, access, start, end);
+  }
+
+  async disconnect(bearerJwt: string): Promise<{ ok: boolean }> {
+    const sub = await requireSubFromBearer(bearerJwt);
+    await getSupabaseAdmin()
+      .from("monix_gsc_credentials")
+      .delete()
+      .eq("user_id", sub);
+    return { ok: true };
+  }
+
+  async syncTargets(
+    bearerJwt: string,
+  ): Promise<{ ok: boolean; targets: number; errors: number }> {
+    const sub = await requireSubFromBearer(bearerJwt);
+    const db = getSupabaseAdmin();
+    const { data: row } = await db
+      .from("monix_gsc_credentials")
+      .select("user_id")
+      .eq("user_id", sub)
+      .maybeSingle();
+    if (!row) {
+      throw Object.assign(
+        new Error("Google Search Console is not connected."),
+        { status: 400 },
+      );
+    }
+    const { data: targets } = await db
+      .from("monix_targets")
+      .select("id, url")
+      .eq("owner_id", sub)
+      .order("created_at", { ascending: false });
+    const list = (targets ?? []) as { id: string; url: string }[];
+    let errors = 0;
+    for (const t of list) {
+      try {
+        await syncTargetSearchConsole(sub, t.id, t.url);
+      } catch {
+        errors += 1;
+      }
+    }
+    return { ok: true, targets: list.length, errors };
+  }
+}

--- a/web/src/server/scan/analyze-url-engine.ts
+++ b/web/src/server/scan/analyze-url-engine.ts
@@ -1,0 +1,626 @@
+/**
+ * TypeScript port of the Django scan pipeline (subset of Python scan_engine).
+ * Produces shapes compatible with WebSecurityAnalysis in the web client.
+ */
+
+import { randomUUID } from "node:crypto";
+import dns from "node:dns/promises";
+import tls from "node:tls";
+import { URL } from "node:url";
+
+export type JsonRecord = Record<string, unknown>;
+
+const UA =
+  "Mozilla/5.0 (compatible; Monix/1.0; +https://monix.dev) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36";
+
+function normalizeUrl(raw: string): string {
+  const t = raw.trim();
+  if (!t.startsWith("http://") && !t.startsWith("https://")) {
+    return `https://${t}`;
+  }
+  return t;
+}
+
+async function checkSsl(hostname: string, port = 443): Promise<JsonRecord> {
+  const result: JsonRecord = {
+    valid: false,
+    subject: "",
+    issuer: "",
+    expires: null as string | null,
+    renewed: null as string | null,
+    serial_number: "",
+    error: null as string | null,
+  };
+  return await new Promise((resolve) => {
+    const socket = tls.connect(
+      {
+        host: hostname,
+        port,
+        servername: hostname,
+        rejectUnauthorized: false,
+        timeout: 5000,
+      },
+      () => {
+        try {
+          const cert = socket.getPeerCertificate(true);
+          if (cert && Object.keys(cert).length) {
+            result.valid = !socket.authorizationError;
+            result.subject = cert.subject ?? "";
+            result.issuer = cert.issuer ?? "";
+            result.serial_number = String(cert.serialNumber ?? "");
+            if (cert.valid_to)
+              result.expires = new Date(cert.valid_to).toISOString();
+            if (cert.valid_from)
+              result.renewed = new Date(cert.valid_from).toISOString();
+          }
+        } catch (e) {
+          result.error = e instanceof Error ? e.message : "ssl_error";
+        }
+        socket.end();
+        resolve(result);
+      },
+    );
+    socket.on("error", (e: Error) => {
+      result.error = e.message;
+      resolve(result);
+    });
+    socket.setTimeout(5000, () => {
+      result.error = "timeout";
+      socket.destroy();
+      resolve(result);
+    });
+  });
+}
+
+async function checkDns(domain: string): Promise<JsonRecord> {
+  const out: JsonRecord = {
+    a: [] as string[],
+    aaaa: [],
+    mx: [],
+    ns: [],
+    txt: [],
+    error: null,
+  };
+  try {
+    out.a = (await dns.resolve4(domain)) as string[];
+  } catch {
+    /* ignore */
+  }
+  try {
+    out.aaaa = (await dns.resolve6(domain)) as string[];
+  } catch {
+    /* ignore */
+  }
+  try {
+    out.mx = (await dns.resolveMx(domain)).map(
+      (m) => `${m.priority} ${m.exchange}`,
+    );
+  } catch {
+    /* ignore */
+  }
+  try {
+    out.ns = await dns.resolveNs(domain);
+  } catch {
+    /* ignore */
+  }
+  try {
+    out.txt = (await dns.resolveTxt(domain)).map((chunks) => chunks.join(""));
+  } catch {
+    /* ignore */
+  }
+  return out;
+}
+
+async function fetchFinalResponse(
+  url: string,
+  maxRedirects = 8,
+): Promise<{
+  status: number;
+  headers: Record<string, string>;
+  finalUrl: string;
+}> {
+  let current = url;
+  for (let i = 0; i < maxRedirects; i++) {
+    const res = await fetch(current, {
+      method: "GET",
+      redirect: "manual",
+      headers: { "User-Agent": UA, Accept: "text/html,*/*" },
+      signal: AbortSignal.timeout(12000),
+    });
+    const loc = res.headers.get("location");
+    if (res.status >= 300 && res.status < 400 && loc) {
+      current = new URL(loc, current).href;
+      continue;
+    }
+    const h: Record<string, string> = {};
+    res.headers.forEach((v, k) => {
+      h[k.toLowerCase()] = v;
+    });
+    return { status: res.status, headers: h, finalUrl: current };
+  }
+  throw new Error("too_many_redirects");
+}
+
+const SECURITY_HEADER_KEYS = [
+  "strict-transport-security",
+  "content-security-policy",
+  "x-frame-options",
+  "x-content-type-options",
+  "referrer-policy",
+  "permissions-policy",
+];
+
+export async function analyzeWebSecurity(
+  url: string,
+  includePortScan: boolean,
+  includeMetadata: boolean,
+): Promise<JsonRecord> {
+  const u = normalizeUrl(url);
+  const parsed = new URL(u);
+  const domain = parsed.hostname;
+  const path = parsed.pathname || "/";
+
+  let ip: string | null = null;
+  try {
+    const r = await dns.lookup(domain);
+    ip = r.address;
+  } catch {
+    /* ignore */
+  }
+
+  const results: JsonRecord = {
+    status: "success",
+    url: u,
+    domain,
+    path,
+    ip_address: ip,
+  };
+
+  if (parsed.protocol === "https:") {
+    results.ssl_certificate = await checkSsl(domain);
+  } else {
+    results.ssl_certificate = { valid: false, error: "Not HTTPS" };
+  }
+
+  results.dns_records = domain
+    ? await checkDns(domain)
+    : { error: "No domain" };
+
+  let http: JsonRecord = { error: "fetch_failed" };
+  try {
+    const fr = await fetchFinalResponse(u);
+    const sec: Record<string, string | null> = {};
+    for (const k of SECURITY_HEADER_KEYS) {
+      sec[k] = fr.headers[k] ?? null;
+    }
+    const present = SECURITY_HEADER_KEYS.filter((k) =>
+      Boolean(fr.headers[k]),
+    ).length;
+    const pct = Math.round((present / SECURITY_HEADER_KEYS.length) * 100);
+    http = {
+      headers: fr.headers,
+      security_headers: sec,
+      status_code: fr.status,
+      final_url: fr.finalUrl,
+      response_time_ms: null,
+    };
+    results.http_headers = http;
+    results.security_headers_analysis = {
+      percentage: pct,
+      score: pct,
+      max_score: 100,
+      headers: Object.fromEntries(
+        SECURITY_HEADER_KEYS.map((k) => [
+          k,
+          { present: Boolean(fr.headers[k]), value: fr.headers[k] ?? null },
+        ]),
+      ),
+    };
+    const server = fr.headers.server || fr.headers["x-powered-by"] || "";
+    results.technologies = {
+      server: server || undefined,
+      cms: "",
+      framework: "",
+      cdn: "",
+      languages: [] as string[],
+    };
+    if (includeMetadata) {
+      const htmlRes = await fetch(fr.finalUrl, {
+        headers: { "User-Agent": UA },
+        signal: AbortSignal.timeout(10000),
+      });
+      const html = await htmlRes.text();
+      const titleM = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+      const descM = html.match(
+        /<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i,
+      );
+      results.metadata = {
+        title: titleM?.[1]?.trim(),
+        description: descM?.[1]?.trim(),
+      };
+    }
+  } catch (e) {
+    results.http_headers = {
+      error: e instanceof Error ? e.message : "http_error",
+    };
+  }
+
+  results.security_txt = { present: false };
+  try {
+    const st = await fetch(`https://${domain}/.well-known/security.txt`, {
+      headers: { "User-Agent": UA },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (st.ok) {
+      const c = await st.text();
+      results.security_txt = {
+        present: true,
+        content: c.slice(0, 4000),
+        url: st.url,
+      };
+    }
+  } catch {
+    /* ignore */
+  }
+
+  results.server_location = ip
+    ? {
+        org: "",
+        city: "",
+        region: "",
+        country: "",
+        timezone: "",
+        coordinates: undefined as
+          | { latitude: number; longitude: number }
+          | undefined,
+      }
+    : { error: "No IP" };
+
+  if (ip) {
+    try {
+      const geo = await fetch(`https://ipinfo.io/${ip}/json`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (geo.ok) {
+        const j = (await geo.json()) as JsonRecord;
+        const loc = (j.loc as string | undefined)?.split(",");
+        results.server_location = {
+          org: String(j.org ?? ""),
+          city: String(j.city ?? ""),
+          region: String(j.region ?? ""),
+          country: String(j.country ?? ""),
+          timezone: String(j.timezone ?? ""),
+          coordinates:
+            loc && loc.length === 2
+              ? { latitude: Number(loc[0]), longitude: Number(loc[1]) }
+              : undefined,
+        };
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  results.port_scan =
+    includePortScan && ip
+      ? {
+          open_ports: [] as number[],
+          closed_ports: [] as number[],
+          error: "port_scan_not_implemented",
+        }
+      : {
+          open_ports: [],
+          closed_ports: [],
+          error: includePortScan ? undefined : "skipped",
+        };
+
+  const findings: Array<{
+    severity: "info" | "low" | "medium" | "high";
+    title: string;
+    detail: string;
+  }> = [];
+  const ssl = results.ssl_certificate as JsonRecord;
+  if (!ssl?.valid) {
+    findings.push({
+      severity: "high",
+      title: "TLS certificate",
+      detail: String(ssl?.error || "invalid"),
+    });
+  }
+  results.findings = findings;
+  results.recommendations = [] as string[];
+  results.scan_profile = includePortScan ? "full" : "fast";
+  results.summary = {
+    https: parsed.protocol === "https:",
+    redirect_hops: 0,
+    cookie_count: 0,
+    open_port_count: 0,
+    missing_header_count: 0,
+    security_txt_present: Boolean((results.security_txt as JsonRecord).present),
+  };
+
+  return results;
+}
+
+export async function runSeoChecks(url: string): Promise<JsonRecord> {
+  const u = normalizeUrl(url);
+  const checks: Record<
+    string,
+    { status: "pass" | "warn" | "fail"; detail: string }
+  > = {};
+  let score = 0;
+  try {
+    const fr = await fetchFinalResponse(u);
+    const htmlRes = await fetch(fr.finalUrl, {
+      headers: { "User-Agent": UA },
+      signal: AbortSignal.timeout(10000),
+    });
+    const html = await htmlRes.text();
+    const titleM = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+    const title = titleM?.[1]?.trim() ?? "";
+    if (title.length >= 30 && title.length <= 70) {
+      checks.meta_title = {
+        status: "pass",
+        detail: "Title length looks reasonable.",
+      };
+      score += 20;
+    } else if (title) {
+      checks.meta_title = {
+        status: "warn",
+        detail: "Title present but length not ideal.",
+      };
+      score += 10;
+    } else {
+      checks.meta_title = { status: "fail", detail: "Missing title." };
+    }
+    const descM = html.match(
+      /<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i,
+    );
+    const desc = descM?.[1]?.trim() ?? "";
+    if (desc.length >= 120) {
+      checks.meta_description = {
+        status: "pass",
+        detail: "Description present.",
+      };
+      score += 15;
+    } else if (desc) {
+      checks.meta_description = {
+        status: "warn",
+        detail: "Description short.",
+      };
+      score += 8;
+    } else {
+      checks.meta_description = {
+        status: "fail",
+        detail: "Missing meta description.",
+      };
+    }
+    checks.robots_txt = { status: "warn", detail: "Not checked in fast path." };
+    checks.sitemap_xml = {
+      status: "warn",
+      detail: "Not checked in fast path.",
+    };
+    checks.canonical_tag = html.includes('rel="canonical"')
+      ? { status: "pass", detail: "Canonical present." }
+      : { status: "warn", detail: "No canonical." };
+    checks.h1_tag = /<h1[\s>]/i.test(html)
+      ? { status: "pass", detail: "H1 present." }
+      : { status: "warn", detail: "No H1." };
+    checks.og_tags = /property=["']og:title["']/i.test(html)
+      ? { status: "pass", detail: "Open Graph tags detected." }
+      : { status: "warn", detail: "Limited Open Graph tags." };
+    score = Math.min(100, score + 25);
+  } catch (e) {
+    return {
+      checks: {},
+      seo_score: 0,
+      error: e instanceof Error ? e.message : "seo_error",
+    };
+  }
+  return { checks, seo_score: score };
+}
+
+export async function runPerformanceChecks(url: string): Promise<JsonRecord> {
+  const key = process.env.PAGESPEED_API_KEY?.trim();
+  const u = normalizeUrl(url);
+  const strat = async (strategy: "mobile" | "desktop") => {
+    const params = new URLSearchParams({ url: u, strategy });
+    if (key) params.set("key", key);
+    try {
+      const r = await fetch(
+        `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?${params}`,
+        {
+          signal: AbortSignal.timeout(25000),
+        },
+      );
+      if (!r.ok) {
+        const j = await r.json().catch(() => ({}));
+        const msg =
+          (j as { error?: { message?: string } }).error?.message ||
+          r.statusText;
+        return {
+          performance_score: null,
+          accessibility_score: null,
+          best_practices_score: null,
+          lcp: null,
+          fid: null,
+          cls: null,
+          error: msg,
+        };
+      }
+      const data = (await r.json()) as JsonRecord;
+      const cats = (data.lighthouseResult as JsonRecord)?.categories as
+        | Record<string, { score?: number }>
+        | undefined;
+      const perf =
+        cats?.performance?.score != null
+          ? Math.round(cats.performance.score * 100)
+          : null;
+      const a11y =
+        cats?.accessibility?.score != null
+          ? Math.round(cats.accessibility.score * 100)
+          : null;
+      const bp =
+        cats?.["best-practices"]?.score != null
+          ? Math.round(cats["best-practices"].score * 100)
+          : null;
+      return {
+        performance_score: perf,
+        accessibility_score: a11y,
+        best_practices_score: bp,
+        lcp: null,
+        fid: null,
+        cls: null,
+        error: null,
+      };
+    } catch (e) {
+      return {
+        performance_score: null,
+        accessibility_score: null,
+        best_practices_score: null,
+        lcp: null,
+        fid: null,
+        cls: null,
+        error: e instanceof Error ? e.message : "pagespeed_error",
+      };
+    }
+  };
+  const [mobile, desktop] = await Promise.all([
+    strat("mobile"),
+    strat("desktop"),
+  ]);
+  return { mobile, desktop };
+}
+
+function statusScore(s: string): number {
+  return s === "pass" ? 1 : s === "warn" ? 0.5 : 0;
+}
+
+function calculateSecurityScore(security: JsonRecord): number {
+  const ssl = security.ssl_certificate as JsonRecord | undefined;
+  const sslStatus = ssl?.valid ? "pass" : "fail";
+  const pct = (security.security_headers_analysis as JsonRecord)?.percentage as
+    | number
+    | undefined;
+  let hdr = "fail";
+  if (typeof pct === "number") {
+    if (pct >= 70) hdr = "pass";
+    else if (pct >= 30) hdr = "warn";
+  }
+  const st = security.security_txt as JsonRecord | undefined;
+  const stStatus = st?.present ? "pass" : "fail";
+  const w = { ssl: 50, security_headers: 40, security_txt: 10 };
+  const total = w.ssl + w.security_headers + w.security_txt;
+  const weighted =
+    w.ssl * statusScore(sslStatus) +
+    w.security_headers * statusScore(hdr) +
+    w.security_txt * statusScore(stStatus);
+  return Math.round((weighted / total) * 100);
+}
+
+function calculateSeoScore(seo: JsonRecord): number {
+  const s = seo.seo_score;
+  return typeof s === "number" ? Math.round(s) : 0;
+}
+
+function calculatePerformanceScore(perf: JsonRecord): number {
+  const m = perf.mobile as JsonRecord | undefined;
+  const d = perf.desktop as JsonRecord | undefined;
+  const scores = [m?.performance_score, d?.performance_score].filter(
+    (x): x is number => typeof x === "number",
+  );
+  if (!scores.length) return 0;
+  return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+}
+
+export function calculateOverallScore(
+  security: JsonRecord,
+  seo: JsonRecord,
+  performance: JsonRecord,
+  includePerformance: boolean,
+): { overall: number; security: number; seo: number; performance: number } {
+  const sec = calculateSecurityScore(security);
+  const se = calculateSeoScore(seo);
+  const perf = includePerformance ? calculatePerformanceScore(performance) : 0;
+  let overall: number;
+  if (includePerformance) {
+    overall = Math.round(sec * 0.5 + se * 0.3 + perf * 0.2);
+  } else {
+    overall = Math.round(sec * (0.5 / 0.8) + se * (0.3 / 0.8));
+  }
+  return { overall, security: sec, seo: se, performance: perf };
+}
+
+export async function runFullUrlAnalysis(opts: {
+  url: string;
+  fullScan: boolean;
+  includePortScan: boolean;
+  includeMetadata: boolean;
+  includePerformance: boolean;
+  targetId: string | null;
+  persist: boolean;
+}): Promise<JsonRecord> {
+  let u = opts.url.trim();
+  if (!u.startsWith("http://") && !u.startsWith("https://")) u = `https://${u}`;
+  const full = opts.fullScan;
+  let includePort = opts.includePortScan;
+  let includeMeta = opts.includeMetadata;
+  let includePerf = opts.includePerformance;
+  if (full) {
+    includePort = true;
+    includeMeta = true;
+    includePerf = true;
+  }
+  const security = await analyzeWebSecurity(u, includePort, includeMeta);
+  const seo = await runSeoChecks(u);
+  const performance = includePerf
+    ? await runPerformanceChecks(u)
+    : {
+        mobile: { performance_score: null, error: "skipped_fast_scan" },
+        desktop: { performance_score: null, error: "skipped_fast_scan" },
+      };
+  const scores = calculateOverallScore(security, seo, performance, includePerf);
+  security.seo = seo;
+  security.performance = performance;
+  security.lighthouse_ran = includePerf;
+  security.scores = scores;
+  Object.assign(security, scores);
+  if (opts.persist) {
+    const reportId = randomUUID();
+    security.report_id = reportId;
+    security.report_url = `/dashboard/report/${reportId}`;
+    const { getSupabaseAdmin } = await import("@/server/db/supabase-admin");
+    const { syncTargetSearchConsole } = await import(
+      "@/server/integrations/gsc-api"
+    );
+    const db = getSupabaseAdmin();
+    const expires = new Date();
+    expires.setDate(expires.getDate() + 30);
+    const owner = opts.targetId
+      ? await resolveTargetOwner(opts.targetId)
+      : null;
+    await db.from("monix_scans").insert({
+      target_id: opts.targetId,
+      report_id: reportId,
+      url: u,
+      score: scores.overall,
+      results: security,
+      is_expired: false,
+      expires_at: expires.toISOString(),
+    });
+    if (owner && opts.targetId) {
+      await syncTargetSearchConsole(owner, opts.targetId, u);
+    }
+  }
+  return security;
+}
+
+async function resolveTargetOwner(targetId: string): Promise<string | null> {
+  const { getSupabaseAdmin } = await import("@/server/db/supabase-admin");
+  const { data } = await getSupabaseAdmin()
+    .from("monix_targets")
+    .select("owner_id")
+    .eq("id", targetId)
+    .maybeSingle();
+  return (data as { owner_id?: string } | null)?.owner_id ?? null;
+}

--- a/web/src/server/services/gsc-service.ts
+++ b/web/src/server/services/gsc-service.ts
@@ -1,13 +1,14 @@
 import type {
   GscAnalyticsRequest,
+  GscConnectContext,
   GscRepository,
 } from "@/server/domain/integrations";
 
 export class GscService {
   constructor(private readonly repo: GscRepository) {}
 
-  getConnectAuthorizationUrl(token: string) {
-    return this.repo.connectUrl(token);
+  getConnectAuthorizationUrl(ctx: GscConnectContext) {
+    return this.repo.connectUrl(ctx);
   }
 
   handleOAuthCallback(query: string) {

--- a/web/src/server/transport/http.ts
+++ b/web/src/server/transport/http.ts
@@ -16,6 +16,16 @@ export function handleRouteError(error: unknown): NextResponse {
       { status: error.status },
     );
   }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as { status: unknown }).status === "number"
+  ) {
+    const status = (error as { status: number }).status;
+    const message = error instanceof Error ? error.message : "Request failed";
+    return NextResponse.json({ error: message }, { status });
+  }
   const message =
     error instanceof Error ? error.message : "Internal server error";
   return NextResponse.json({ error: message }, { status: 500 });

--- a/web/src/types/fernet.d.ts
+++ b/web/src/types/fernet.d.ts
@@ -1,0 +1,11 @@
+declare module "fernet" {
+  interface FernetToken {
+    encode(message?: string): string;
+    decode(token?: string): string;
+  }
+  const Fernet: {
+    Secret: new (secret64: string) => unknown;
+    Token: new (opts: Record<string, unknown>) => FernetToken;
+  };
+  export = Fernet;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This continues the Django → Next.js serverless migration by moving core authenticated APIs and integrations onto Route Handlers backed by Supabase (service role) and a TypeScript scan pipeline.

## What changed

- **Client API base** (`web/src/lib/api.ts`): browser calls use same-origin `/api/*`; SSR uses `NEXT_PUBLIC_SITE_URL` or `VERCEL_URL` (fallback `http://127.0.0.1:3000`). Dual-read verification still hits legacy Django via `NEXT_PUBLIC_DJANGO_URL` when enabled.
- **GSC + Cloudflare** (`web/src/server/bootstrap/integrations.ts`): default implementations use `SupabaseGscRepository` and `SupabaseCloudflareRepository` (Google OAuth + token storage, Cloudflare REST/GraphQL).
- **Data routes**: targets, scans (list/locations/run), analyze-url, reports (public share + authenticated `/api/me/reports/:id`), auth me, account delete, health, and stubbed dashboard/system/connections/alerts.
- **Scan engine** (`web/src/server/scan/analyze-url-engine.ts`): TS port for security/SEO/PageSpeed scoring and persistence to `monix_scans` (subset of Python behavior).
- **Schema**: `supabase/migrations/000002_monix_user_names.sql` adds `first_name` / `last_name` on `monix_users`.
- **Env docs** (`.env.example`): `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SITE_URL`, optional `MONIX_GSC_STATE_SECRET`, Next GSC redirect URI note.
- **Dependencies**: `fernet` for at-rest token encryption compatible with Django’s Fernet field.

## Deploy / configure

- Apply Supabase migrations (`000001` + `000002`) and set **SUPABASE_SERVICE_ROLE_KEY** on the Next server.
- Set **GOOGLE_REDIRECT_URI** to the Next callback, e.g. `https://<app>/api/gsc/callback` (Google Console must match exactly).
- Optional: **MONIX_GSC_STATE_SECRET** for OAuth state signing (otherwise derived from existing secrets).

## Testing

- `bun run lint` and `bun run build` (web) pass; existing unit tests pass.

## Follow-ups (not in this PR)

- Remove or archive the `core/` Django tree once parity and data migration are verified.
- Replace stubbed dashboard/monitoring endpoints with real metrics or drop unused UI.
- Port scan parity (port scan, richer SEO, collectors) beyond the current TS subset.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dde6e73-358e-4ddf-b3ea-05a7b251b2f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dde6e73-358e-4ddf-b3ea-05a7b251b2f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

